### PR TITLE
delete default compute engine service account stability fix

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -104,8 +104,7 @@ resource "google_compute_shared_vpc_service_project" "shared_vpc_attachment" {
   Default compute service account retrieval
  *****************************************/
 data "google_compute_default_service_account" "default" {
-  project    = "${local.project_id}"
-  depends_on = ["google_project_service.project_services"]
+  project = "${google_project.project.id}"
 }
 
 /******************************************
@@ -113,10 +112,15 @@ data "google_compute_default_service_account" "default" {
  *****************************************/
 resource "null_resource" "delete_default_compute_service_account" {
   provisioner "local-exec" {
-    command = "${path.module}/scripts/delete-default-compute-service-account.sh ${local.project_id} ${var.credentials_path} ${data.google_compute_default_service_account.default.id}"
+    command = "${path.module}/scripts/delete-service-account.sh ${local.project_id} ${var.credentials_path} ${data.google_compute_default_service_account.default.id}"
   }
 
-  depends_on = ["google_project_service.project_services"]
+  triggers {
+    default_service_account = "${data.google_compute_default_service_account.default.id}"
+    activated_apis          = "${join(",", var.activate_apis)}"
+  }
+
+  depends_on = ["google_project_service.project_services", "data.google_compute_default_service_account.default"]
 }
 
 /******************************************

--- a/scripts/delete-service-account.sh
+++ b/scripts/delete-service-account.sh
@@ -22,9 +22,11 @@ SA_ID=$3
 
 export CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=$CREDENTIALS
 
-if [ -n "$SA_ID" ]; then
-    echo "Deleting the compute default service account in project $PROJECT_ID"
+SA_LIST=$(gcloud --project="$PROJECT_ID" iam service-accounts list || exit 1)
+
+if [[ $SA_LIST = *"$SA_ID"* ]]; then
+    echo "Deleting service account $SA_ID in project $PROJECT_ID"
     gcloud iam service-accounts delete --quiet --project="$PROJECT_ID" "$SA_ID"
 else
-    echo "No service account id passed. Nothing to do."
+    echo "Service account not listed. It appears to have already been deleted."
 fi

--- a/test/integration/gcloud/integration.bats
+++ b/test/integration/gcloud/integration.bats
@@ -20,7 +20,7 @@
 
   run terraform plan
   [ "$status" -eq 0 ]
-  [[ "$output" =~ 14\ to\ add ]]
+  [[ "$output" =~ 11\ to\ add ]]
   [[ "$output" =~ 0\ to\ change ]]
   [[ "$output" =~ 0\ to\ destroy ]]
 }
@@ -29,7 +29,7 @@
 
   run terraform apply -auto-approve
   [ "$status" -eq 0 ]
-  [[ "$output" =~ 14\ added ]]
+  [[ "$output" =~ 11\ added ]]
   [[ "$output" =~ 0\ changed ]]
   [[ "$output" =~ 0\ destroyed ]]
 }
@@ -140,5 +140,5 @@
 
   run terraform destroy -force
   [ "$status" -eq 0 ]
-  [[ "$output" =~ 14\ destroyed ]]
+  [[ "$output" =~ 11\ destroyed ]]
 }


### PR DESCRIPTION
Uses triggers to account for more cases of existing state of already created projects.