### PR TITLE
Fix errors in integration test runner script.

### DIFF
--- a/test/integration/gcloud/run.sh
+++ b/test/integration/gcloud/run.sh
@@ -19,7 +19,7 @@ TESTDIR=${BASH_SOURCE%/*}
 # Activate test working directory
 function make_testdir() {
   mkdir -p "$TEMPDIR"
-  cp -r "$TESTDIR/*" "$TEMPDIR"
+  cp -r "$TESTDIR"/* "$TEMPDIR"
 }
 
 # Activate test config
@@ -98,7 +98,7 @@ output "project_info_example" {
 }
 
 output "project_info_number" {
-  value       = "${module.project-factory.project_number"
+  value       = "${module.project-factory.project_number}"
 }
 
 output "domain_example" {


### PR DESCRIPTION
There are a couple of small errors in the integration testing script
causing the tests to fail.

The first is a mis-placed glob inside of a double quoted string; instead
of copying all of the files in a directory to a tempdir the test runner
tried to copy the literal file "test/integration/tmp/*", and would
subsequently fail to run terraform since no configurations were present.
This has been corrected by moving the asterisk outside of the quotes so
that it can be properly expanded.

The second issue is an omitted curly brace in the templated
`outputs.tf`, which has been restored.