### PR TITLE
Change service account IAM project membership to be additive

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -42,6 +42,8 @@ locals {
   gsuite_group           = "${var.group_name != "" || var.create_group}"
   app_engine_enabled     = "${length(keys(var.app_engine)) > 0 ? true : false}"
 
+  shared_vpc_users       = "${compact(list(local.s_account_fmt, data.null_data_source.data_group_email_format.outputs["group_fmt"], local.api_s_account_fmt, local.gke_s_account_fmt))}"
+
   app_engine_config = {
     enabled  = "${list(var.app_engine)}"
     disabled = "${list()}"
@@ -182,15 +184,12 @@ resource "google_service_account_iam_binding" "service_account_grant_to_group" {
 /*************************************************************************************
   compute.networkUser role granted to GSuite group, APIs Service account, Project Service Account, and GKE Service Account on shared VPC
  *************************************************************************************/
-resource "google_project_iam_binding" "controlling_group_vpc_role" {
-  count = "${var.shared_vpc != "" && length(compact(var.shared_vpc_subnets)) == 0 ? 1 : 0}"
+resource "google_project_iam_member" "controlling_group_vpc_membership" {
+  count = "${var.shared_vpc != "" && length(compact(var.shared_vpc_subnets)) == 0 ? length(local.shared_vpc_users) : 0}"
 
   project = "${var.shared_vpc}"
   role    = "roles/compute.networkUser"
-
-  members = [
-    "${compact(list(local.s_account_fmt, data.null_data_source.data_group_email_format.outputs["group_fmt"], local.api_s_account_fmt, local.gke_s_account_fmt))}",
-  ]
+  member = "${element(local.shared_vpc_users, count.index)}"
 
   depends_on = ["google_project_service.project_services"]
 }

--- a/main.tf
+++ b/main.tf
@@ -146,14 +146,12 @@ resource "google_service_account" "default_service_account" {
 /**************************************************
   Policy to operate instances in shared subnetwork
  *************************************************/
-resource "google_project_iam_binding" "default_service_account_policy" {
+resource "google_project_iam_member" "default_service_account_membership" {
   count   = "${var.sa_role != "" ? 1 : 0}"
   project = "${local.project_id}"
   role    = "${var.sa_role}"
 
-  members = [
-    "${local.s_account_fmt}",
-  ]
+  member = "${local.s_account_fmt}"
 }
 
 /******************************************

--- a/test/integration/gcloud/integration.bats
+++ b/test/integration/gcloud/integration.bats
@@ -177,6 +177,28 @@
   [[ "$output" =~ No\ changes ]]
 }
 
+@test "Confirm Terraform network user IAM management is additive" {
+  if [ "${SHARED_VPC}" == "" ]; then
+    skip "SHARED_VPC variable not set, skipping network user IAM management test"
+  fi
+
+  export SA_ID="sa-${RANDOM}"
+  export PROJECT_ID="$(terraform output project_info_example)"
+
+  run gcloud iam service-accounts create "$SA_ID" \
+    --project "$PROJECT_ID"
+  [ "$status" -eq 0 ]
+
+  run gcloud projects add-iam-policy-binding \
+      $SHARED_VPC \
+      --member "serviceAccount:${SA_ID}@${PROJECT_ID}.iam.gserviceaccount.com" \
+      --role "roles/compute.networkUser"
+  [ "$status" -eq 0 ]
+
+  run terraform plan
+  [[ "$output" =~ No\ changes ]]
+}
+
 @test "Test App Engine app created with the correct settings" {
 
   PROJECT_ID="$(terraform output project_info_example)"

--- a/test/integration/gcloud/run.sh
+++ b/test/integration/gcloud/run.sh
@@ -70,6 +70,7 @@ module "project-factory" {
   group_role               = "$GROUP_ROLE"
   group_name               = "$GROUP_NAME"
   shared_vpc               = "$SHARED_VPC"
+  sa_role                  = "$SA_ROLE"
   sa_group                 = "$SA_GROUP"
   folder_id                = "$FOLDER_ID"
   activate_apis            = ["compute.googleapis.com", "container.googleapis.com"]


### PR DESCRIPTION
When the project factory module was managing the default service account
membership (as set with the `sa_role` variable), it was authoritatively
managing and as a result would remove members added elsewhere. This
commit replaces the authoritative binding management with an additive
binding management.

This pull request was developed with #15 but does not include that pull
request in this branch; that branch should be merged first so that the
tests in this PR can be checked.