### PR TITLE
Change service account IAM management to be additive

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -170,15 +170,13 @@ resource "google_project_iam_member" "gsuite_group_role" {
 /******************************************
   Granting serviceAccountUser to group
  *****************************************/
-resource "google_service_account_iam_binding" "service_account_grant_to_group" {
+resource "google_service_account_iam_member" "service_account_grant_to_group" {
   count = "${local.gsuite_group ? 1 : 0}"
 
   service_account_id = "projects/${local.project_id}/serviceAccounts/${google_service_account.default_service_account.email}"
   role               = "roles/iam.serviceAccountUser"
 
-  members = [
-    "${data.null_data_source.data_group_email_format.outputs["group_fmt"]}",
-  ]
+  member = "${data.null_data_source.data_group_email_format.outputs["group_fmt"]}"
 }
 
 /*************************************************************************************

--- a/test/integration/gcloud/run.sh
+++ b/test/integration/gcloud/run.sh
@@ -109,6 +109,10 @@ output "domain_example" {
 output "group_email_example" {
   value       = "${module.project-factory.group_email}"
 }
+
+output "service_account_email" {
+  value = "${module.project-factory.service_account_email}"
+}
 EOF
 }
 


### PR DESCRIPTION
The IAM management granting a G Suite group access to the project
factory service account was authoritative and would remove members added
elsewhere. This commit replaces the authoritative binding management
with additive binding management.