### PR TITLE
Make `org_id` and `roles/organization.viewer` role optional

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -20,7 +20,13 @@ variable "random_project_id" {
 }
 
 variable "org_id" {
-  description = "The organization id for the associated services"
+  description = "The organization id (optional if `domain` is passed)"
+  default     = ""
+}
+
+variable "domain" {
+  description = "The domain name (optional if `org_id` is passed)"
+  default     = ""
 }
 
 variable "name" {


### PR DESCRIPTION
Currently the `org_id` is used to get the domain name required to create / get a GSuite group named `<group_name>@<domain>`. 

The domain name is gotten using the `google_organization` resource that requires the `roles/organization.viewer` role. This resource should be activated only if `group_name` is passed. 

Currently when `group_name` is not passed, the `google_organization` resource is still called, and that will fail if for some reason one does not have the Organization Viewer role.

This PR makes `org_id` optional and adds support for a `domain` flag that will replace the it in the previous scenario, so that the project creation can still go on. 