### PR TITLE
Work in progress: Manage multiple service accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ module "project-factory" {
   billing_account     = "ABCDEF-ABCDEF-ABCDEF"
   group_role          = "roles/editor"
   shared_vpc          = "shared_vpc_host_name"
-  sa_group            = "test_sa_group@yourdomain.com"
   credentials_path    = "${local.credentials_file_path}"
 
   shared_vpc_subnets = [
@@ -42,7 +41,6 @@ The Project Factory module will take the following actions:
 1. Delete the default compute service account.
 1. Create a new default service account for the project.
     1. Give it access to the shared VPC (to be able to launch instances).
-    1. Add it to the `sa_group` in Google Groups, if specified.
 1. Attach the billing account (`billing_account`) to the project.
 1. Create a new Google Group for the project (`group_name`) if `create_group` is `true`.
 1. Give the controlling group access to the project, with the `group_role`.
@@ -60,7 +58,6 @@ The roles granted are specifically:
 - New Default Service Account
   - `compute.networkUser` on host project or specified subnets
   - `storage.admin` on `bucket_name` GCS bucket
-  - MEMBER of the specified `sa_group`
 - `group_name` is the new controlling group
   - `compute.networkUser` on host project or specific subnets
   - Specified `group_role` on project
@@ -94,8 +91,6 @@ The roles granted are specifically:
 | name | The name for the project | string | - | yes |
 | org_id | The organization id for the associated services | string | - | yes |
 | random_project_id | Enables project random id generation | string | `false` | no |
-| sa_group | A GSuite group to place the default Service Account for the project in | string | `` | no |
-| sa_role | A role to give the default Service Account for the project (defaults to none) | string | `` | no |
 | shared_vpc | The ID of the host project which hosts the shared VPC | string | `` | no |
 | shared_vpc_subnets | List of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id) | list | `<list>` | no |
 | usage_bucket_name | Name of a GCS bucket to store GCE usage reports in (optional) | string | `` | no |

--- a/gsuite_override.tf
+++ b/gsuite_override.tf
@@ -37,19 +37,6 @@ data "null_data_source" "data_final_group_email" {
   }
 }
 
-/***********************************************
-  Make service account member of sa_group group
- ***********************************************/
-resource "gsuite_group_member" "service_account_sa_group_member" {
-  count = "${var.sa_group != "" ? 1 : 0}"
-
-  group = "${var.sa_group}"
-  email = "${google_service_account.default_service_account.email}"
-  role  = "MEMBER"
-
-  depends_on = ["google_service_account.default_service_account"]
-}
-
 /******************************************
   Gsuite Group Configuration
  *****************************************/

--- a/gsuite_override.tf
+++ b/gsuite_override.tf
@@ -24,7 +24,7 @@ it is necessary to delete this file that contains the gsuite resources.
  *****************************************/
 data "null_data_source" "data_given_group_email" {
   inputs {
-    given_group_email = "${var.create_group == "false" ? format("%s@%s", var.group_name, local.domain) : ""}"
+    given_group_email = "${var.create_group == "false" && var.group_name != "" ? format("%s@%s", var.group_name, local.domain) : ""}"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -326,3 +326,14 @@ resource "google_project_iam_member" "gke_host_agent" {
 
   depends_on = ["google_project_service.project_services"]
 }
+
+/******************************************
+  Delegate service account generation to the service_accounts module
+ *****************************************/
+module "service_accounts" {
+  source             = "./modules/service_accounts"
+  project_id         = "${google_project.project.project_id}"
+  credentials_path   = "${var.credentials_path}"
+  shared_vpc_subnets = "${var.shared_vpc_subnets}"
+  service_accounts   = "${var.service_accounts}"
+}

--- a/main.tf
+++ b/main.tf
@@ -274,9 +274,10 @@ resource "google_project_iam_member" "gke_host_agent" {
   Delegate service account generation to the service_accounts module
  *****************************************/
 module "service_accounts" {
-  source             = "./modules/service_accounts"
-  project_id         = "${google_project.project.project_id}"
-  credentials_path   = "${var.credentials_path}"
-  shared_vpc_subnets = "${var.shared_vpc_subnets}"
-  service_accounts   = "${var.service_accounts}"
+  source                  = "./modules/service_accounts"
+  project_id              = "${google_project.project.project_id}"
+  credentials_path        = "${var.credentials_path}"
+  shared_vpc_subnets      = "${var.shared_vpc_subnets}"
+  service_accounts        = "${var.service_accounts}"
+  impersonated_user_email = "${var.impersonated_user_email}"
 }

--- a/modules/service_accounts/main.tf
+++ b/modules/service_accounts/main.tf
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_service_account" "project_service_accounts" {
+  count = "${length(var.service_accounts)}"
+
+  account_id   = "${lookup(var.service_accounts[count.index], "account_id")}"
+  display_name = "${lookup(var.service_accounts[count.index], "description")}"
+  project      = "${var.project_id}"
+}
+
+resource "null_resource" "service_accounts_role_granting" {
+  provisioner "local-exec" {
+    command = "${path.module}/scripts/service_accounts_role_granting.sh '${jsonencode(var.service_accounts)}' '${var.project_id}' '${var.credentials_path}' add"
+  }
+
+  provisioner "local-exec" {
+    command = "${path.module}/scripts/service_accounts_role_granting.sh '${jsonencode(var.service_accounts)}' '${var.project_id}' '${var.credentials_path}' destroy"
+    when    = "destroy"
+  }
+
+  triggers {
+      service_accounts = "${jsonencode(var.service_accounts)}"
+  }
+
+  depends_on = ["google_service_account.project_service_accounts"]
+}
+
+resource "null_resource" "service_accounts_vpc_subnets_sharing" {
+  provisioner "local-exec" {
+    command = "bash ${path.module}/scripts/service_accounts_vpc_subnets_sharing.sh '${jsonencode(var.service_accounts)}' '${var.project_id}' '${jsonencode(var.shared_vpc_subnets)}' '${var.credentials_path}' add"
+  }
+
+  provisioner "local-exec" {
+    command = "bash ${path.module}/scripts/service_accounts_vpc_subnets_sharing.sh '${jsonencode(var.service_accounts)}' '${var.project_id}' '${jsonencode(var.shared_vpc_subnets)}' '${var.credentials_path}' destroy"
+    when    = "destroy"
+  }
+
+  triggers {
+      service_accounts   = "${jsonencode(var.service_accounts)}"
+      shared_vpc_subnets = "${jsonencode(var.shared_vpc_subnets)}"
+  }
+
+  depends_on = ["google_service_account.project_service_accounts", "null_resource.service_accounts_role_granting"]
+}
+
+resource "null_resource" "service_accounts_groups_membership" {
+  count = "${var.impersonated_user_email != "" ? 1 : 0}"
+
+  provisioner "local-exec" {
+    command = "python3 ${path.module}/scripts/service_accounts_group_membership.py --service_accounts '${jsonencode(var.service_accounts)}' --project_id '${var.project_id}' --path '${var.credentials_path}' --email '${var.impersonated_user_email}' --action add"
+  }
+
+  provisioner "local-exec" {
+    command = "python3 ${path.module}/scripts/service_accounts_group_membership.py --service_accounts '${jsonencode(var.service_accounts)}' --project_id '${var.project_id}' --path '${var.credentials_path}' --email '${var.impersonated_user_email}' --action destroy"
+    when    = "destroy"
+  }
+
+  triggers {
+      service_accounts = "${jsonencode(var.service_accounts)}"
+  }
+
+  depends_on = ["google_service_account.project_service_accounts"]
+}

--- a/modules/service_accounts/outputs.tf
+++ b/modules/service_accounts/outputs.tf
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "service_account_emails" {
+  description = "The email addresses of the generated service accounts"
+  value       = "TODO"
+}

--- a/modules/service_accounts/scripts/service_accounts_group_membership.py
+++ b/modules/service_accounts/scripts/service_accounts_group_membership.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import logging
+import sys
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+from google.oauth2 import service_account
+
+
+logger = logging.getLogger(__name__)
+
+
+def create_parser():
+    """
+    Function to parse and return arguments passed in.
+    """
+    parser = argparse.ArgumentParser(
+        description='Manage service account membership in G Suite groups.'
+    )
+
+    parser.add_argument(
+            '--project_id',
+            help='The project containing the service accounts to manage.')
+    parser.add_argument(
+            '--path',
+            help='The service account credentials file.')
+    parser.add_argument(
+            '--email',
+            help='The email address to impersonate when managing '
+                 'group membership.')
+    parser.add_argument('--service_accounts', help='json of service accounts')
+    parser.add_argument('--action', help='')
+
+    return parser
+
+
+class GsuiteAPI(object):
+
+    SCOPES = [
+        'https://www.googleapis.com/auth/admin.directory.group',
+        'https://www.googleapis.com/auth/admin.directory.group.member'
+    ]
+
+    def __init__(self, credentials_path=None, email=None):
+        if credentials_path is None:
+            raise Exception("Missing service account credentials file")
+
+        if email is None:
+            raise Exception("Missing directory admin email address")
+
+        self.create_service(credentials_path, email)
+
+    def create_service(self, credentials_path, email):
+        """
+        Load service account credentials from disk and then impersonate the
+        user with Directory Admin permissions on the target domain.
+
+        The service account needs access to act as the provided user account.
+        For more information see
+        https://developers.google.com/admin-sdk/directory/v1/guides/delegation
+        """
+        credentials = service_account.Credentials.from_service_account_file(
+                credentials_path,
+                scopes=self.__class__.SCOPES)
+        delegated = credentials.with_subject(email)
+
+        self.service = build('admin', 'directory_v1', credentials=delegated)
+
+    def add_members(self, project_id, service_accounts):
+        ca_dict = json.loads(service_accounts)
+
+        succeeded = True
+        for ca in ca_dict:
+            for group in ca.get('groups', []):
+
+                account_id = ca.get('account_id', None)
+
+                try:
+                    if account_id is not None:
+                        email = '{0}@{1}.iam.gserviceaccount.com'.format(
+                                account_id, project_id)
+
+                        logger.info("Adding {} to {}".format(email, group))
+                        self.service.members().insert(
+                            groupKey=group,
+                            body={'email': email}
+                        ).execute()
+
+                except HttpError as exception:
+                    msg = '{0} - {1}'.format(email, exception._get_reason())
+                    logger.error(msg)
+                    succeeded = False
+
+        return succeeded
+
+    def remove_members(self, project_id, service_accounts):
+        ca_dict = json.loads(service_accounts)
+
+        succeeded = True
+        for ca in ca_dict:
+            for group in ca.get('groups', []):
+
+                account_id = ca.get('account_id', None)
+
+                try:
+                    if account_id is not None:
+                        email = '{0}@{1}.iam.gserviceaccount.com'.format(
+                                account_id, project_id)
+
+                        logger.info("Removing {} from {}".format(email, group))
+                        self.service.members().delete(
+                            groupKey=group,
+                            memberKey=email
+                        ).execute()
+
+                except HttpError as exception:
+                    msg = '{0} - {1}'.format(email, exception._get_reason())
+                    logger.error(msg)
+                    succeeded = True
+
+        return succeeded
+
+
+def main():
+
+    parser = create_parser()
+    args = parser.parse_args()
+
+    gsuite_api = GsuiteAPI(
+        credentials_path=args.path,
+        email=args.email,
+    )
+
+    if args.action == 'add':
+        succeeded = gsuite_api.add_members(
+                args.project_id,
+                args.service_accounts)
+        if not succeeded:
+            sys.exit(1)
+
+    elif args.action == 'destroy':
+        succeeded = gsuite_api.remove_members(
+                args.project_id,
+                args.service_accounts)
+        if not succeeded:
+            sys.exit(1)
+
+    else:
+        logger.fatal(
+            "Unhandled action '{}', " +
+            "must be one of ('add', 'destroy')".format(args.action))
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.ERROR)
+    logger.setLevel(logging.INFO)
+    main()

--- a/modules/service_accounts/scripts/service_accounts_group_membership.py
+++ b/modules/service_accounts/scripts/service_accounts_group_membership.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python3
 
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import json
 import logging

--- a/modules/service_accounts/scripts/service_accounts_role_granting.sh
+++ b/modules/service_accounts/scripts/service_accounts_role_granting.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+#set -e
+
+# Store service_account variable
+ARRAY="$1"
+# Either "roles" or "groups"
+PROJECT="$2"
+# Credentials
+CREDENTIALS="$3"
+# Operation, either "add" or "destroy"
+OPERATION="$4"
+
+# Export credentials for gcloud commands
+export CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=$CREDENTIALS
+
+# Get service accounts list
+SERVICE_ACCOUNTS=$(echo "$ARRAY" | jq -r '.[].account_id')
+
+# Service accounts to array
+IFS=$'\n' read -d ' ' -a SERVICE_ACCOUNTS_ARRAY <<< "$SERVICE_ACCOUNTS"
+
+# Each service account's roles are formatted in one string
+for SERVICE_ACCOUNT in "${SERVICE_ACCOUNTS_ARRAY[@]}"
+do
+  ROLES=$(echo "$ARRAY" | jq -r --arg service_account "$SERVICE_ACCOUNT" '.[] | select(.account_id==$service_account) | .roles[]?')
+  IFS=$'\n' read -d ' ' -a ROLES_ARRAY <<< "$ROLES"
+
+  for ROLE in "${ROLES_ARRAY[@]}"
+  do
+    if [[ "$OPERATION" = "add" ]]
+    then
+      gcloud projects add-iam-policy-binding "$PROJECT" --member="serviceAccount:$SERVICE_ACCOUNT@$PROJECT.iam.gserviceaccount.com" --role="$ROLE"
+      sleep 10 #intentional delay due to gcloud error when a policy is updated more than once in a row.
+    elif [[ "$OPERATION" = "destroy" ]]
+    then
+      gcloud projects remove-iam-policy-binding "$PROJECT" --member="serviceAccount:$SERVICE_ACCOUNT@$PROJECT.iam.gserviceaccount.com" --role="$ROLE"
+      sleep 5
+    fi
+  done
+done

--- a/modules/service_accounts/scripts/service_accounts_role_granting.sh
+++ b/modules/service_accounts/scripts/service_accounts_role_granting.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #set -e
 
 # Store service_account variable

--- a/modules/service_accounts/scripts/service_accounts_vpc_subnets_sharing.sh
+++ b/modules/service_accounts/scripts/service_accounts_vpc_subnets_sharing.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+
+# Array with service accounts data
+ARRAY="$1"
+
+# Host project where subnet is
+PROJECT=$2
+
+# Subnets to add policy
+SUBNETS=$3
+
+# Credentials path
+CREDENTIALS=$4
+
+# Operation, either "add" or "destroy"
+OPERATION="$5"
+
+# Role to grant
+ROLE="roles/compute.networkUser"
+
+export CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=$CREDENTIALS
+
+# Create json temp file
+FILE_NAME="temp_$RANDOM.json"
+touch $FILE_NAME
+chown $(whoami) $FILE_NAME
+
+# Helper function for string splitting
+function get_sub_string_split(){
+  STRING="$1"
+  SEPARATOR="$2"
+  PART=$3
+  IFS="$SEPARATOR" read -ra SPLIT <<< $STRING
+  echo "${SPLIT[$PART]}"
+}
+
+# Writes a new policy to file
+function write_new_policy(){
+  echo "Writing policy from scratch"
+  SERVICE_ACCOUNT="$1"
+  cat <<EOF > $FILE_NAME
+{
+  "bindings": [
+    {
+      "members": [
+        "serviceAccount:$SERVICE_ACCOUNT"
+      ],
+      "role": "$ROLE"
+    }
+  ],
+}
+EOF
+}
+
+# Updates a policy that already has the role and some members
+function update_policy(){
+  echo "Updating policy"
+  CURRENT_POLICY="$1"
+  SERVICE_ACCOUNT="$2"
+  OPERATION="$3"
+  if [[ "$OPERATION" = "add" ]]
+  then
+    CURRENT_POLICY=$(echo "$CURRENT_POLICY" | jq -r --arg ROLE "$ROLE" --arg SERVICE_ACCOUNT "$SERVICE_ACCOUNT" '(.bindings?[]? | select(.role == $ROLE) | .members) |= .+ ["serviceAccount:"+$SERVICE_ACCOUNT]')
+  elif [[ "$OPERATION" = "destroy" ]]
+  then
+    CURRENT_POLICY=$(echo "$CURRENT_POLICY" | jq -r --arg ROLE "$ROLE" --arg SERVICE_ACCOUNT "$SERVICE_ACCOUNT" '(.bindings?[]? | select(.role == $ROLE) | .members) |= .- ["serviceAccount:"+$SERVICE_ACCOUNT]')
+  fi
+
+  echo "$CURRENT_POLICY" > "$FILE_NAME"
+}
+
+# Add/remove a binding to policy
+function add_binding(){
+  echo "Adding new binding"
+  CURRENT_POLICY="$1"
+  SERVICE_ACCOUNT="$2"
+  CURRENT_POLICY=$(echo "$CURRENT_POLICY" | jq -r --arg SERVICE_ACCOUNT "$SERVICE_ACCOUNT" --arg ROLE "$ROLE" '.bindings? |= .+ [{"members":["serviceAccount:"+$SERVICE_ACCOUNT]} + {"role":$ROLE} ]')
+  echo "$CURRENT_POLICY" > "$FILE_NAME"
+}
+
+# Cleans the file
+function clean_file(){
+  echo "" > $FILE_NAME
+}
+
+# Get service accounts list
+SERVICE_ACCOUNTS=$(echo "$ARRAY" | jq -r '.[] | select(.network_access == "1") | .account_id')
+
+# Service accounts to array
+IFS=$'\n' read -d ' ' -a SERVICE_ACCOUNTS_ARRAY <<< "$SERVICE_ACCOUNTS"
+
+# Set the iam-policy per each service account and per each subnet
+for SERVICE_ACCOUNT in "${SERVICE_ACCOUNTS_ARRAY[@]}"
+do
+  #Formatted service account
+  SERVICE_ACCOUNT_FMT="$SERVICE_ACCOUNT@$PROJECT.iam.gserviceaccount.com"
+
+  # Subnets formatting
+  SUBNETS_FMT=$(echo "$SUBNETS" | jq -r '.[]')
+
+  # Subnets array
+  IFS=$'\n' read -d ' ' -a SUBNETS_ARRAY <<< "$SUBNETS_FMT"
+
+  for SUBNET in "${SUBNETS_ARRAY[@]}"
+  do
+
+    # Var to control whether to apply the command or not
+    APPLY_COMMAND=1
+
+    # Subnet data retrieval
+    NAME=$(get_sub_string_split "$SUBNET" "/" 5)
+    REGION=$(get_sub_string_split "$SUBNET" "/" 3)
+    PROJECT_HOST=$(get_sub_string_split "$SUBNET" "/" 1)
+
+    # We take the current policy
+    CURRENT_POLICY=$(gcloud beta compute networks subnets get-iam-policy "$NAME" --region="$REGION" --project="$PROJECT_HOST" --format=json)
+    # If it's void, we write a new one
+    if [[ $(echo "$CURRENT_POLICY" | jq '.bindings?[]?') == "" ]]
+    then
+      if [[ "$OPERATION" = "add" ]]
+      then
+        write_new_policy "$SERVICE_ACCOUNT_FMT"
+      elif [[ "$OPERATION" = "destroy" ]]
+      then
+        APPLY_COMMAND=0
+      fi
+
+    # If it already has a binding with the role, we update the policy
+    elif [[ $(echo "$CURRENT_POLICY" | jq -r --arg ROLE "$ROLE" '.bindings?[]? | select(.role == $ROLE)') != "" ]];
+    then
+      update_policy "$CURRENT_POLICY" "$SERVICE_ACCOUNT_FMT" "$OPERATION"
+    elif [[ "$OPERATION" = "add" ]]
+    then
+      add_binding "$CURRENT_POLICY" "$SERVICE_ACCOUNT_FMT"
+    fi
+
+    # Perform the command
+    if [[ $APPLY_COMMAND -eq 1 ]]
+    then
+      gcloud beta compute networks subnets set-iam-policy "$NAME" $FILE_NAME --region "$REGION" --project "$PROJECT_HOST" --quiet
+    fi
+    clean_file
+  done
+
+done
+
+rm -f $FILE_NAME

--- a/modules/service_accounts/scripts/service_accounts_vpc_subnets_sharing.sh
+++ b/modules/service_accounts/scripts/service_accounts_vpc_subnets_sharing.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Array with service accounts data
 ARRAY="$1"
 

--- a/modules/service_accounts/variables.tf
+++ b/modules/service_accounts/variables.tf
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  type        = "string"
+  description = "The ID of the project where service accounts will be created"
+}
+
+variable "service_accounts" {
+  type        = "list"
+  description = "A list of service accounts to create"
+}
+
+variable "credentials_path" {
+  type        = "string"
+  description = "Credentials for managing service accounts"
+}
+
+variable "shared_vpc_subnets" {
+  type        = "list"
+  description = "Shared VPC subnets that service accounts with network access will be able to manage"
+  default     = []
+}
+
+variable "impersonated_user_email" {
+  type = "string"
+  default = ""
+  description = "The email address to use when managing service account group membership"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -32,31 +32,6 @@ output "group_email" {
   description = "The email of the created GSuite group with group_name"
 }
 
-output "service_account_id" {
-  value       = "${google_service_account.default_service_account.account_id}"
-  description = "The id of the default service account"
-}
-
-output "service_account_display_name" {
-  value       = "${google_service_account.default_service_account.display_name}"
-  description = "The display name of the default service account"
-}
-
-output "service_account_email" {
-  value       = "${google_service_account.default_service_account.email}"
-  description = "The email of the default service account"
-}
-
-output "service_account_name" {
-  value       = "${google_service_account.default_service_account.name}"
-  description = "The fully-qualified name of the default service account"
-}
-
-output "service_account_unique_id" {
-  value       = "${google_service_account.default_service_account.unique_id}"
-  description = "The unique id of the default service account"
-}
-
 output "project_bucket_self_link" {
   value       = "${google_storage_bucket.project_bucket.*.self_link}"
   description = "Project's bucket selfLink"

--- a/test/integration/gcloud/.kitchen.yml
+++ b/test/integration/gcloud/.kitchen.yml
@@ -1,0 +1,33 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+driver:
+  name: "terraform"
+  command_timeout: 1800
+
+provisioner:
+  name: "terraform"
+
+transport:
+  name: exec
+
+platforms:
+  - name: local
+
+verifier:
+  name: inspec
+
+suites:
+  - name: "default"

--- a/test/integration/gcloud/Gemfile
+++ b/test/integration/gcloud/Gemfile
@@ -1,0 +1,18 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source 'https://rubygems.org/' do
+  gem 'kitchen-terraform', '~> 3.3'
+  gem 'kitchen-inspec', :git => 'https://github.com/inspec/kitchen-inspec.git', :ref => '0590f1b'
+end

--- a/test/integration/gcloud/integration.bats
+++ b/test/integration/gcloud/integration.bats
@@ -215,8 +215,8 @@
   [[ "${lines[0]}" = "authDomain: $AUTH_DOMAIN" ]]
   [[ "${lines[4]}" = "featureSettings: {}" ]]
   [[ "${lines[6]}" = "id: $PROJECT_ID" ]]
-  [[ "${lines[7]}" = "name: apps/$PROJECT_ID" ]]
-  [[ "${lines[8]}" = "locationId: $REGION" ]]
+  [[ "${lines[7]}" = "locationId: $REGION" ]]
+  [[ "${lines[8]}" = "name: apps/$PROJECT_ID" ]]
   [[ "${lines[9]}" = "servingStatus: SERVING" ]]
 }
 

--- a/test/integration/gcloud/integration.bats
+++ b/test/integration/gcloud/integration.bats
@@ -59,7 +59,6 @@
 @test "Test information about project $PROJECT_ID" {
 
   export PROJECT_ID="$(terraform output project_info_example)"
-  export GROUP_EMAIL="$(terraform output group_email_example)"
 
   run gcloud config set project $PROJECT_ID
   run gcloud projects describe $PROJECT_ID --format=flattened[no-pad]
@@ -70,7 +69,6 @@
 @test "Test the correct apis are activated" {
 
   export PROJECT_ID="$(terraform output project_info_example)"
-  export GROUP_EMAIL="$(terraform output group_email_example)"
 
   run gcloud services list
   [ "$status" -eq 0 ]
@@ -84,7 +82,6 @@
 @test "Test that project has the shared vpc associated (host project)" {
 
   PROJECT_ID="$(terraform output project_info_example)"
-  GROUP_EMAIL="$(terraform output group_email_example)"
 
   run gcloud compute shared-vpc get-host-project $PROJECT_ID --format="get(name)"
   [ "$status" -eq 0 ]
@@ -94,7 +91,6 @@
 @test "Test project has only the expected service accounts" {
 
   export PROJECT_ID="$(terraform output project_info_example)"
-  export GROUP_EMAIL="$(terraform output group_email_example)"
 
   run gcloud iam service-accounts list --format="get(email)"
   [ "$status" -eq 0 ]
@@ -127,7 +123,6 @@
 @test "Test project has enabled the usage report export to the bucket" {
 
   export PROJECT_ID="$(terraform output project_info_example)"
-  export GROUP_EMAIL="$(terraform output group_email_example)"
 
   run gcloud compute project-info describe --format="flattened[no-pad](usageExportLocation)"
   [ "$status" -eq 0 ]

--- a/test/integration/gcloud/integration.bats
+++ b/test/integration/gcloud/integration.bats
@@ -214,7 +214,7 @@
   [ "$status" -eq 0 ]
   [[ "${lines[0]}" = "authDomain: $AUTH_DOMAIN" ]]
   [[ "${lines[4]}" = "featureSettings: {}" ]]
-  [[ "${lines[6]}" = "id: $PROJECT_ID}" ]]
+  [[ "${lines[6]}" = "id: $PROJECT_ID" ]]
   [[ "${lines[7]}" = "name: apps/$PROJECT_ID" ]]
   [[ "${lines[8]}" = "locationId: $REGION" ]]
   [[ "${lines[9]}" = "servingStatus: SERVING" ]]

--- a/test/integration/gcloud/integration.bats
+++ b/test/integration/gcloud/integration.bats
@@ -155,30 +155,6 @@
   [[ "${lines[2]}" = "roles/container.hostServiceAgentUser" ]]
 }
 
-@test "Confirm Terraform project IAM management is additive" {
-  if [ "$SA_ROLE" == "" ]; then
-    skip "SA_ROLE variable not set, skipping project IAM management test"
-  fi
-
-  PROJECT_ID="$(terraform output project_info_example)"
-  SA_ID="sa-${RANDOM}"
-  SA_EMAIL="${SA_ID}@${PROJECT_ID}.iam.gserviceaccount.com"
-
-  gcloud iam service-accounts create "$SA_ID" \
-    --project "$PROJECT_ID"
-
-  gcloud projects add-iam-policy-binding \
-      $PROJECT_ID \
-      --member "serviceAccount:${SA_EMAIL}" \
-      --role "$SA_ROLE"
-
-  run terraform plan
-  [[ "$output" =~ No\ changes ]]
-
-  # tear down test iam account
-  gcloud --quiet iam service-accounts delete "$SA_EMAIL" --project "$PROJECT_ID"
-}
-
 @test "Confirm Terraform network user IAM management is additive" {
   if [ "${SHARED_VPC}" == "" ]; then
     skip "SHARED_VPC variable not set, skipping network user IAM management test"

--- a/test/integration/gcloud/run.sh
+++ b/test/integration/gcloud/run.sh
@@ -70,8 +70,6 @@ module "project-factory" {
   group_role               = "$GROUP_ROLE"
   group_name               = "$GROUP_NAME"
   shared_vpc               = "$SHARED_VPC"
-  sa_role                  = "$SA_ROLE"
-  sa_group                 = "$SA_GROUP"
   folder_id                = "$FOLDER_ID"
   activate_apis            = ["compute.googleapis.com", "container.googleapis.com"]
   credentials_path         = "\${local.credentials_file_path}"

--- a/test/integration/gcloud/run.sh
+++ b/test/integration/gcloud/run.sh
@@ -107,10 +107,6 @@ output "domain_example" {
 output "group_email_example" {
   value       = "${module.project-factory.group_email}"
 }
-
-output "service_account_email" {
-  value = "${module.project-factory.service_account_email}"
-}
 EOF
 }
 

--- a/test/integration/gcloud/sample.sh
+++ b/test/integration/gcloud/sample.sh
@@ -23,7 +23,6 @@
 export ORG_ID="0000000000"
 export BILLING_ACCOUNT="XXXXXX-XXXXXX-XXXXXX"
 export SHARED_VPC="gcp-foundation-shared-host"
-export SA_GROUP="gcp-svc-accounts@example.com"
 export USAGE_BUCKET_NAME="gcp-foundation-usage-export"
 export GSUITE_ADMIN_ACCOUNT="admin@clearify.com"
 export CREDENTIALS_PATH="$HOME/sa-key.json"

--- a/test/integration/gcloud/test/integration/default/controls/project-factory.rb
+++ b/test/integration/gcloud/test/integration/default/controls/project-factory.rb
@@ -1,0 +1,59 @@
+# encoding: utf-8
+
+outputs = terraform_outputs()
+project_id = outputs.project_info_example
+
+control 'project-services' do
+  title 'Project services activated by the project factory'
+
+  describe google_project_services(project: project_id) do
+    it { should exist }
+    its('services') { should include "compute.googleapis.com" }
+    its('services') { should include "appengine.googleapis.com" }
+  end
+end
+
+control 'service-accounts' do
+  title 'Service accounts created and managed by the project factory'
+
+  describe google_service_accounts(project: project_id) do
+    its('emails') { should include "project-service-account@#{project_id}.iam.gserviceaccount.com" }
+    its('emails') { should include "#{project_id}@appspot.gserviceaccount.com" }
+  end
+end
+
+control 'shared-vpc' do
+  title 'Access to a shared VPC host project and associated subnets'
+
+  only_if { ENV['SHARED_VPC'] }
+
+  describe command("gcloud compute shared-vpc get-host-project #{project_id} --format='get(name)'") do
+    its('exit_status') { should eq 0 }
+    its('stdout.strip') { should eq ENV['SHARED_VPC'] }
+  end
+
+  describe google_project_iam_binding(
+    project: ENV['SHARED_VPC'],
+    role: 'roles/compute.networkUser'
+  ) do
+    it { should exist }
+    its('members') { should include "serviceAccount:project-service-account@#{project_id}.iam.gserviceaccount.com" }
+
+    it {
+      require 'pp'
+      pp subject.binding
+    }
+  end
+end
+
+control 'gsuite-group-roles' do
+  title "Roles granted to an optional G Suite group"
+
+  only_if { ENV['GSUITE_GROUP'] }
+end
+
+control 'usage-bucket' do
+  title "Usage report exporting"
+
+  only_if { ENV['USAGE_BUCKET_NAME'] }
+end

--- a/test/integration/gcloud/test/integration/default/inspec.yml
+++ b/test/integration/gcloud/test/integration/default/inspec.yml
@@ -1,0 +1,4 @@
+name: project-factory
+title: Terraform Google Project Factory
+license: Apache-2.0
+version: 0.1.0

--- a/test/integration/gcloud/test/integration/default/libraries/google_compute_subnetwork_iam_binding.rb
+++ b/test/integration/gcloud/test/integration/default/libraries/google_compute_subnetwork_iam_binding.rb
@@ -1,0 +1,55 @@
+require 'open3'
+
+class GoogleComputeSubnetIamBinding < Inspec.resource(1)
+  name 'google_compute_subnet_iam_binding'
+
+  def initialize(subnet:, role:)
+    @subnet = subnet
+    @project, @region, @name = destructure_subnet(subnet)
+    @role = role
+
+    set_iam_binding()
+  end
+
+  def exist?
+    !@binding.nil?
+  end
+
+  def members
+    @binding.nil? ? [] : @binding['members']
+  end
+
+  def to_s
+    "Subnet IAM #{@subnet.inspect} binding #{@role}"
+  end
+
+  private
+
+  def set_iam_binding()
+    policy = fetch_iam_policy()
+    bindings = policy['bindings']
+    if bindings
+      @binding = bindings.find { |b| b['role'] == @role }
+    end
+  end
+
+  def fetch_iam_policy()
+    cmd = "gcloud beta compute networks subnets get-iam-policy #{@name} " +
+          "--region='#{@region}' --project='#{@project}' --format=json"
+
+    out, err, status = Open3.capture3(cmd)
+    if status.exitstatus != 0
+      raise Inspec::Exceptions::ResourceFailed, "Cannot fetch IAM policy for subnetwork #{@subnet.inspect}: #{err}"
+    end
+    JSON.load(out)
+  end
+
+  def destructure_subnet(subnet)
+    pattern = %r[\Aprojects/(.*?)/regions/(.*?)/subnetworks/(.*?)\z]
+    if (match = subnet.match(pattern))
+      return match[1], match[2], match[3]
+    else
+      raise Inspec::Exceptions::ResourceFailed, "Subnetwork #{subnet.inspect} does not match pattern #{pattern.inspect}"
+    end
+  end
+end

--- a/test/integration/gcloud/test/integration/default/libraries/google_project_iam_binding.rb
+++ b/test/integration/gcloud/test/integration/default/libraries/google_project_iam_binding.rb
@@ -1,0 +1,45 @@
+require 'open3'
+
+class GoogleProjectIamBinding < Inspec.resource(1)
+  name 'google_project_iam_binding'
+
+  def initialize(project:, role:)
+    @project = project
+    @role    = role
+  end
+
+  def exist?
+    !binding.nil?
+  end
+
+  def members
+    if exist?
+      binding['members']
+    else
+      []
+    end
+  end
+
+  def binding
+    @binding ||= set_iam_binding
+  end
+
+  private
+
+  def set_iam_binding()
+    policy = fetch_iam_policy()
+    bindings = policy['bindings']
+    if bindings
+      @binding = bindings.find { |b| b['role'] == @role }
+    end
+  end
+
+  def fetch_iam_policy()
+    cmd = "gcloud projects get-iam-policy #{@project} --format json"
+
+    out, _err, status = Open3.capture3(cmd)
+    if status.exitstatus == 0
+      JSON.load(out)
+    end
+  end
+end

--- a/test/integration/gcloud/test/integration/default/libraries/google_service_accounts.rb
+++ b/test/integration/gcloud/test/integration/default/libraries/google_service_accounts.rb
@@ -1,0 +1,35 @@
+require 'open3'
+
+class GoogleServiceAccounts < Inspec.resource(1)
+  name 'google_service_accounts'
+
+  attr_reader :service_accounts
+
+  def initialize(project: )
+    @project  = project
+    @service_accounts = nil
+  end
+
+  def exist?
+    !service_accounts.nil?
+  end
+
+  def emails
+    if exist?
+      service_accounts.map { |acct| acct["email"] }
+    end
+  end
+
+  def service_accounts
+    @service_accounts ||= fetch_service_accounts
+  end
+
+  private
+
+  def fetch_service_accounts()
+    result = inspec.command("gcloud iam service-accounts list --project #{@project} --format='json'")
+    if result.exit_status == 0
+      @service_accounts = JSON.load(result.stdout)
+    end
+  end
+end

--- a/test/integration/gcloud/test/integration/default/libraries/terraform_outputs.rb
+++ b/test/integration/gcloud/test/integration/default/libraries/terraform_outputs.rb
@@ -1,0 +1,44 @@
+require 'open3'
+require 'json'
+
+class TerraformOutputs < Inspec.resource(1)
+  name 'terraform_outputs'
+
+  def initialize(dir: Dir.getwd(), mod: nil)
+    @dir = dir
+    @mod = mod
+    read_outputs()
+  end
+
+  def exist?
+    !@outputs.nil?
+  end
+
+  def method_missing(m, *args)
+    key = m.to_s
+    if exist? && @outputs.key?(key)
+      @outputs[key]["value"]
+    else
+      nil
+    end
+  end
+
+  def to_s
+    "Terraform outputs (#{@dir})"
+  end
+
+  private
+
+  def read_outputs
+    cmd = "terraform output -json"
+    if @mod
+      cmd << " -module #{@mod}"
+    end
+
+    out, _err, status = Open3.capture3(cmd, chdir: @dir)
+
+    if status.exitstatus == 0
+      @outputs = JSON.load(out)
+    end
+  end
+end

--- a/variables.tf
+++ b/variables.tf
@@ -129,3 +129,11 @@ variable "app_engine" {
   type        = "map"
   default     = {}
 }
+
+variable "service_accounts" {
+  description = "A list of service accounts to create in the project"
+  type        = "list"
+
+  default = [
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -62,16 +62,6 @@ variable "group_role" {
   default     = "roles/editor"
 }
 
-variable "sa_group" {
-  description = "A GSuite group to place the default Service Account for the project in"
-  default     = ""
-}
-
-variable "sa_role" {
-  description = "A role to give the default Service Account for the project (defaults to none)"
-  default     = ""
-}
-
 variable "activate_apis" {
   description = "The list of apis to activate within the project"
   type        = "list"

--- a/variables.tf
+++ b/variables.tf
@@ -135,5 +135,12 @@ variable "service_accounts" {
   type        = "list"
 
   default = [
+    {
+      account_id     = "project-service-account"
+      description    = "Project Service Account"
+      roles          = []
+      groups         = []
+      network_access = true
+    },
   ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -134,3 +134,9 @@ variable "service_accounts" {
     },
   ]
 }
+
+variable "impersonated_user_email" {
+  type = "string"
+  default = ""
+  description = "The email address to use when managing service account group membership"
+}


### PR DESCRIPTION
This pull request adds support for managing multiple service accounts in a given project.

### API changes

```diff
variables:
+ service_accounts
+ impersonated_user_email
- sa_role
- sa_group

outputs:
- service_account_id
- service_account_email
- service_account_name
- service_account_display_name

resources:
- service account membership in "roles/storage.admin" on the project bucket
- G Suite group membership in "roles/iam.serviceAccountUser" on the default service account
```

### TODO

* [ ] Add kitchen-terraform tests
* [ ] Verify that changing the `service_accounts` variable doesn't mangle role deletion/recreation
* [ ] G Suite group access to service accounts
* [ ] Service accounts with network access have `roles/compute.networkUser` on the shared VPC project

This pull request is a work in progress and may be rebased if necessary.