### PR TITLE
Fail helper script when variables are unset (fixes #25)

### DIFF
--- a/helpers/setup-sa.sh
+++ b/helpers/setup-sa.sh
@@ -15,6 +15,7 @@
 
 
 set -e
+set -u
 
 # Organization ID
 ORG_ID="$(gcloud organizations list --format="value(ID)" --filter="$1")"


### PR DESCRIPTION
In some environments (such as the WSL), variables like `$RANDOM` may be
unset, causing the script to proceed with mangled variables. This commit
prevents those errors by adding `set -u`, which will cause bash to abort
when a variable is used but unset.