### PR TITLE
Add user control over deleting default compute user

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -132,6 +132,7 @@ data "google_compute_default_service_account" "default" {
   Default compute service account deletion
  *****************************************/
 resource "null_resource" "delete_default_compute_service_account" {
+  count = "${var.delete_default_compute_user}"
   provisioner "local-exec" {
     command = "${path.module}/scripts/delete-service-account.sh ${local.project_id} ${var.credentials_path} ${data.google_compute_default_service_account.default.id}"
   }

--- a/variables.tf
+++ b/variables.tf
@@ -129,3 +129,8 @@ variable "app_engine" {
   type        = "map"
   default     = {}
 }
+
+variable "delete_default_compute_user" {
+  description = "Remove the default compute service account"
+  default     = true
+}


### PR DESCRIPTION
Add user control over deleting default compute user

A number of GCP modules such as the [terraform-google-kubernetes-engine][gke]
module default to using the default compute user account, and the
deletion of the default compute user account makes using the
project-factory more complicated. A user's first experience with either
the project-factory or another Terraform that uses GCE resources will
have the following experience:

- User finds an external Terraform module to solve a problem - eg, gke.
- User finds an example usage of that module that requires a `google_project`
- User creates a project-factory based on a minimal example from this module
- Terraform creates a new `google_project`
- Terraform deletes the default compute service account
- User creates a gke module based on a minimal example from that module
- Terraform tries to creates gke resources with a default compute user dependency
- The gke resources fail to create because of the missing dependency
- Terraform crashes out with a confusing error

While we can reasonably opt for a security-first approach we can make
this deletion the default behavior, but we should provide an escape
hatch. Allowing the compute user to be kept means that it'll be a lot
easier for users to spin up prototypes.

[gke]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine

