### PR TITLE
Add explicit dependency for google_project_service

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -107,6 +107,8 @@ resource "google_project_service" "project_services" {
 
   project = "${local.project_id}"
   service = "${element(var.activate_apis, count.index)}"
+
+  depends_on = ["google_project.project"]
 }
 
 /******************************************


### PR DESCRIPTION
The `google_project_service.project_services` resource depends on
the `google_project.project` resource, but Terraform was unable to
detect this dependency though the dependencies of the variables in use.
This could lead to Terraform deleting the project and the project
services at the same time.

This commit resolves the issue by adding an explicit dependency from
`google_project_service.project_services` -> `google_project.project`.