### PR TITLE
Add usage information to helper script

### DIFF
--- a/helpers/setup-sa.sh
+++ b/helpers/setup-sa.sh
@@ -17,6 +17,14 @@
 set -e
 set -u
 
+# check for input variables
+if [ $# -ne 2 ]; then
+  echo
+  echo "Usage: $0 <organization name> <project id>"
+  echo
+  exit 1
+fi
+
 # Organization ID
 ORG_ID="$(gcloud organizations list --format="value(ID)" --filter="$1")"
 
@@ -123,3 +131,4 @@ gcloud services enable \
   --project ${HOST_PROJECT}
 
 echo "All done."
+

--- a/helpers/setup-sa.sh
+++ b/helpers/setup-sa.sh
@@ -131,4 +131,3 @@ gcloud services enable \
   --project ${HOST_PROJECT}
 
 echo "All done."
-


### PR DESCRIPTION
While the documentation of the project clearly specifies how to use this helper script, executing this without the parameters can still be checked and help displayed to the user.  This PR aims to provide useful information when the wrong number of parameters are passed.

Validation of the provided inputs (such as wrong org or project) are handled later in the script.