### PR TITLE
Implement Billing Account Role

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -63,6 +63,10 @@ In order to recover the Terraform configuration, the required APIs need to be en
     # Requires `roles/serviceusage.admin` on $TARGET_PROJECT
     gcloud services enable compute.googleapis.com --project $TARGET_PROJECT
     ```
+    This must be run in the context of the service account that is being used to execute the Project Factory module.  You can add the service account to your list of authentication credentials by issuing the following command and importing your service account key:
+    ```
+    gcloud auth activate-service-account --key-file=path-to-service-account-credentials.json 
+    ```
 
 - - -
 ### Seed project missing APIs

--- a/helpers/setup-sa.sh
+++ b/helpers/setup-sa.sh
@@ -17,6 +17,14 @@
 set -e
 set -u
 
+# check for input variables
+if [ $# -ne 2 ]; then
+  echo
+  echo "Usage: $0 <organization name> <project id>"
+  echo
+  exit 1
+fi
+
 # Organization ID
 ORG_ID="$(gcloud organizations list --format="value(ID)" --filter="$1")"
 
@@ -123,3 +131,4 @@ gcloud services enable \
   --project ${HOST_PROJECT}
 
 echo "All done."
+

--- a/helpers/setup-sa.sh
+++ b/helpers/setup-sa.sh
@@ -175,10 +175,10 @@ if [[ ${BILLING_ACCOUNT:-} != "" ]]; then
 \ \ role: roles/billing.user" policy-tmp-$$.yml
     gcloud beta billing accounts set-iam-policy $BILLING_ACCOUNT policy-tmp-$$.yml
   else
-      echo "Could not set roles/billing.user on service account $SERVICE_ACCOUNT.\
-      Please perform this manually."
+    echo "Could not set roles/billing.user on service account $SERVICE_ACCOUNT.\
+    Please perform this manually."
   fi
-  rm -f policy-tmp-$$.json
+  rm -f policy-tmp-$$.yml
 fi
 
 echo "All done."

--- a/helpers/setup-sa.sh
+++ b/helpers/setup-sa.sh
@@ -131,4 +131,3 @@ gcloud services enable \
   --project ${HOST_PROJECT}
 
 echo "All done."
-


### PR DESCRIPTION
This adds to the helper script the optional creation of the IAM billing role for the service account that is required.  Other small changes include:

- Additional output when the hep script is run so that the user understands what steps are being executed.  This could be helpful for any debugging or failure.
- Explicit details on how to add a service account to the gcloud auth list 