### PR TITLE
Improving documentation for example

### DIFF
--- a/examples/project-hierarchy/README.md
+++ b/examples/project-hierarchy/README.md
@@ -6,6 +6,14 @@ It will do the following:
 - Create a folder on an organization
 - Create two projects under the newly created folder
 
+Note: this example requires for the service account used by terraform to have the role resourcemanager.folderCreator . You can grant this role with the command "gcloud organizations add-iam-policy-binding" as in the example below
+
+```
+gcloud organizations add-iam-policy-binding 1092662220185 \
+  --member="serviceAccount:project-factory-12782@terraform-213322.iam.gserviceaccount.com" \
+  --role="roles/resourcemanager.folderCreator"
+```
+
 Expected variables:
 - `admin_email`
 - `organization_id`
@@ -22,7 +30,7 @@ Expected variables:
 | admin_email | Admin user email on Gsuite | string | - | yes |
 | billing_account | The ID of the billing account to associate this project with | string | - | yes |
 | organization_id | The organization id for the associated services | string | - | yes |
-| credentials_path | Path to a Service Account credentials file with permissions documented in the readme | string | - | yes |
+| credentials_path | Path to a Service Account credentials file with permissions documented in the readme and above| string | - | yes |
 
 ## Outputs
 


### PR DESCRIPTION
The project-hierarchy example requires more permissions than the ones used for the project factory; in particular, it requires folder creation. Documenting this fact and giving an example on how to add this binding.
