### PR TITLE
Correctly expand relative credentials_path attribute (#59)

### DIFF
--- a/test/integration/full/controls/app-engine.rb
+++ b/test/integration/full/controls/app-engine.rb
@@ -17,9 +17,9 @@ project_id       = attribute('project_id')
 region           = attribute('region')
 credentials_path = attribute('credentials_path')
 
-ENV['CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE'] = File.expand_path(
+ENV['CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE'] = File.absolute_path(
   credentials_path,
-  __FILE__)
+  File.join(__dir__, "../../../fixtures/full"))
 
 control 'project-factory-app-engine' do
   title "Project Factory App Engine configuration"

--- a/test/integration/full/controls/gsuite.rb
+++ b/test/integration/full/controls/gsuite.rb
@@ -19,9 +19,9 @@ project_id                  = attribute('project_id')
 service_account_email       = attribute('service_account_email')
 credentials_path            = attribute('credentials_path')
 
-ENV['CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE'] = File.expand_path(
+ENV['CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE'] = File.absolute_path(
   credentials_path,
-  __FILE__)
+  File.join(__dir__, "../../../fixtures/full"))
 
 control 'project-factory-gsuite' do
   title 'Project Factory G Suite integration'

--- a/test/integration/full/controls/project-factory.rb
+++ b/test/integration/full/controls/project-factory.rb
@@ -20,9 +20,9 @@ usage_bucket_name           = attribute('usage_bucket_name')
 usage_bucket_prefix         = attribute('usage_bucket_prefix')
 credentials_path            = attribute('credentials_path')
 
-ENV['CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE'] = File.expand_path(
+ENV['CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE'] = File.absolute_path(
   credentials_path,
-  __FILE__)
+  File.join(__dir__, "../../../fixtures/full"))
 
 control 'project-factory' do
   title 'Project Factory'

--- a/test/integration/full/controls/shared-vpc.rb
+++ b/test/integration/full/controls/shared-vpc.rb
@@ -20,9 +20,9 @@ service_account_email       = attribute('service_account_email')
 shared_vpc                  = attribute('shared_vpc')
 credentials_path            = attribute('credentials_path')
 
-ENV['CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE'] = File.expand_path(
+ENV['CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE'] = File.absolute_path(
   credentials_path,
-  __FILE__)
+  File.join(__dir__, "../../../fixtures/full"))
 
 control 'project-factory-shared-vpc' do
   title "Project Factory shared VPC"

--- a/test/integration/minimal/controls/minimal.rb
+++ b/test/integration/minimal/controls/minimal.rb
@@ -16,9 +16,9 @@ project_id            = attribute('project_id')
 service_account_email = attribute('service_account_email')
 credentials_path      = attribute('credentials_path')
 
-ENV['CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE'] = File.expand_path(
+ENV['CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE'] = File.absolute_path(
   credentials_path,
-  __FILE__)
+  File.join(__dir__, "../../../fixtures/minimal"))
 
 control 'project-factory-minimal' do
   title 'Project Factory minimal configuration'


### PR DESCRIPTION
The path expansion added in the earlier passes of #34 behaved poorly
when given an absolute path, so support for relative paths was removed
to get that pull request merge. This commit fixes the path expansion to
occur relative to the appropriate fixtures directory.