### PR TITLE
Add lien support to project-factory

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -100,6 +100,17 @@ resource "google_project" "project" {
 }
 
 /******************************************
+  Project lien
+ *****************************************/
+resource "google_resource_manager_lien" "lien" {
+  count        = "${var.lien ? 1 : 0}"
+  parent       = "projects/${google_project.project.number}"
+  restrictions = ["resourcemanager.projects.delete"]
+  origin       = "project-factory"
+  reason       = "Project Factory lien"
+}
+
+/******************************************
   APIs configuration
  *****************************************/
 resource "google_project_service" "project_services" {

--- a/test/fixtures/full/main.tf
+++ b/test/fixtures/full/main.tf
@@ -44,6 +44,7 @@ module "project-factory" {
   sa_role             = "${var.sa_role}"
   sa_group            = "${var.sa_group}"
   credentials_path    = "${var.credentials_path}"
+  lien                = "true"
 
   activate_apis       = [
     "compute.googleapis.com",

--- a/test/integration/full/controls/project-factory.rb
+++ b/test/integration/full/controls/project-factory.rb
@@ -64,6 +64,35 @@ control 'project-factory' do
       expect(service_accounts).to include extra_service_account_email
     end
   end
+
+  describe command("gcloud alpha resource-manager liens list --project #{project_id} --format=json") do
+    its('exit_status') { should be 0 }
+    its('stderr') { should eq '' }
+
+    let(:liens) do
+      if subject.exit_status == 0
+        JSON.parse(subject.stdout, symbolize_names: true)
+      else
+        []
+      end
+    end
+
+    it "has one lien" do
+      expect(liens.count).to eq 1
+    end
+
+    it "sets the lien origin" do
+      expect(liens.first).to include(origin: 'project-factory')
+    end
+
+    it "sets the lien reason" do
+      expect(liens.first).to include(reason: 'Project Factory lien')
+    end
+
+    it "restricts the delete permission on the project" do
+      expect(liens.first).to include(restrictions: ['resourcemanager.projects.delete'])
+    end
+  end
 end
 
 control 'project-factory-sa-role' do

--- a/test/integration/minimal/controls/minimal.rb
+++ b/test/integration/minimal/controls/minimal.rb
@@ -50,4 +50,21 @@ control 'project-factory-minimal' do
 
     it { expect(service_accounts).to include service_account_email }
   end
+
+  describe command("gcloud alpha resource-manager liens list --project #{project_id} --format=json") do
+    its('exit_status') { should be 0 }
+    its('stderr') { should eq '' }
+
+    let(:liens) do
+      if subject.exit_status == 0
+        JSON.parse(subject.stdout, symbolize_names: true)
+      else
+        []
+      end
+    end
+
+    it "has no liens" do
+      expect(liens).to be_empty
+    end
+  end
 end

--- a/variables.tf
+++ b/variables.tf
@@ -129,3 +129,9 @@ variable "app_engine" {
   type        = "map"
   default     = {}
 }
+
+variable "lien" {
+  description = "Add a lien on the project to prevent accidental deletion"
+  default     = "false"
+  type        = "string"
+}


### PR DESCRIPTION
This commit adds a `lien` variable and backing logic to add liens to
GCP projects. This allows users to prevent projects from being
unintentionally deleted.

Because the lien is a Terraform resource, it's still possible to delete
the project with an errant `terraform destroy.