### PR TITLE
Add a `help` target to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,30 +26,30 @@ BUILD_RUBY_VERSION := 2.4.2
 DOCKER_IMAGE_KITCHEN_TERRAFORM := cftk/kitchen_terraform
 DOCKER_TAG_KITCHEN_TERRAFORM ?= ${BUILD_TERRAFORM_VERSION}_${BUILD_CLOUD_SDK_VERSION}_${BUILD_PROVIDER_GOOGLE_VERSION}_${BUILD_PROVIDER_GSUITE_VERSION}
 
-# All is the first target in the file so it will get picked up when you just run 'make' on its own
-all: check_shell check_python check_golang check_terraform check_docker check_base_files test_check_headers check_headers check_trailing_whitespace generate_docs
+
+all: check_shell check_python check_golang check_terraform check_docker check_base_files test_check_headers check_headers check_trailing_whitespace generate_docs ## Run all linters and update documentation
 
 # The .PHONY directive tells make that this isn't a real target and so
 # the presence of a file named 'check_shell' won't cause this target to stop
 # working
 .PHONY: check_shell
-check_shell:
+check_shell: ## Lint shell scripts
 	@source test/make.sh && check_shell
 
 .PHONY: check_python
-check_python:
+check_python: ## Lint Python source files
 	@source test/make.sh && check_python
 
 .PHONY: check_golang
-check_golang:
+check_golang: ## Lint Go source files
 	@source test/make.sh && golang
 
 .PHONY: check_terraform
 check_terraform:
-	@source test/make.sh && check_terraform
+	@source ## Lint Terraform source files
 
 .PHONY: check_docker
-check_docker:
+check_docker: ## Lint Dockerfiles
 	@source test/make.sh && docker
 
 .PHONY: check_base_files
@@ -57,7 +57,7 @@ check_base_files:
 	@source test/make.sh && basefiles
 
 .PHONY: check_shebangs
-check_shebangs:
+check_shebangs: ## Check that scripts have correct shebangs
 	@source test/make.sh && check_bash
 
 .PHONY: check_trailing_whitespace
@@ -70,13 +70,13 @@ test_check_headers:
 	@python test/test_verify_boilerplate.py
 
 .PHONY: check_headers
-check_headers:
+check_headers: ## Check that source files have appropriate boilerplate
 	@echo "Checking file headers"
 	@python test/verify_boilerplate.py
 
 # Integration tests
 .PHONY: test_integration
-test_integration:
+test_integration: ## Run integration tests
 	bundle install
 	bundle exec kitchen create
 	bundle exec kitchen converge
@@ -85,7 +85,7 @@ test_integration:
 	bundle exec kitchen destroy
 
 .PHONY: generate_docs
-generate_docs:
+generate_docs: ## Update README documentation for Terraform variables and outputs
 	@source test/make.sh && generate_docs
 
 # Versioning
@@ -112,40 +112,43 @@ docker_build_kitchen_terraform:
 
 # Run docker
 .PHONY: docker_run
-docker_run:
+docker_run: ## Launch a shell within the Docker test environment
 	docker run --rm -it \
 		-v $(CURDIR):/cftk/workdir \
 		${DOCKER_IMAGE_KITCHEN_TERRAFORM}:${DOCKER_TAG_KITCHEN_TERRAFORM} \
 		/bin/bash
 
 .PHONY: docker_create
-docker_create:
+docker_create: ## Run `kitchen create` within the Docker test environment
 	docker run --rm -it \
 		-v $(CURDIR):/cftk/workdir \
 		${DOCKER_IMAGE_KITCHEN_TERRAFORM}:${DOCKER_TAG_KITCHEN_TERRAFORM} \
 		/bin/bash -c "kitchen create"
 
 .PHONY: docker_converge
-docker_converge:
+docker_converge: ## Run `kitchen converge` within the Docker test environment
 	docker run --rm -it \
 		-v $(CURDIR):/cftk/workdir \
 		${DOCKER_IMAGE_KITCHEN_TERRAFORM}:${DOCKER_TAG_KITCHEN_TERRAFORM} \
 		/bin/bash -c "kitchen converge && kitchen converge"
 
 .PHONY: docker_verify
-docker_verify:
+docker_verify: ## Run `kitchen verify` within the Docker test environment
 	docker run --rm -it \
 		-v $(CURDIR):/cftk/workdir \
 		${DOCKER_IMAGE_KITCHEN_TERRAFORM}:${DOCKER_TAG_KITCHEN_TERRAFORM} \
 		/bin/bash -c "kitchen verify"
 
 .PHONY: docker_destroy
-docker_destroy:
+docker_destroy: ## Run `kitchen destroy` within the Docker test environment
 	docker run --rm -it \
 		-v $(CURDIR):/cftk/workdir \
 		${DOCKER_IMAGE_KITCHEN_TERRAFORM}:${DOCKER_TAG_KITCHEN_TERRAFORM} \
 		/bin/bash -c "kitchen destroy"
 
 .PHONY: test_integration_docker
-test_integration_docker: docker_create docker_converge docker_verify docker_destroy
+test_integration_docker: docker_create docker_converge docker_verify docker_destroy ## Run a full integration test cycle
 	@echo "Running test-kitchen tests in docker"
+
+help: ## Prints help for targets with comments
+	@grep -E '^[a-zA-Z._-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
This commit adds a make target that will print out the available make
targets and descriptions.

Running `make` results in the following text:

```
all                           Run all linters and update documentation
check_docker                  Lint Dockerfiles
check_golang                  Lint Go source files
check_headers                 Check that source files have appropriate boilerplate
check_python                  Lint Python source files
check_shebangs                Check that scripts have correct shebangs
check_shell                   Lint shell scripts
docker_converge               Run `kitchen converge` within the Docker test environment
docker_create                 Run `kitchen create` within the Docker test environment
docker_destroy                Run `kitchen destroy` within the Docker test environment
docker_run                    Launch a shell within the Docker test environment
docker_verify                 Run `kitchen verify` within the Docker test environment
generate_docs                 Update README documentation for Terraform variables and outputs
help                          Prints help for targets with comments
test_integration              Run integration tests
test_integration_docker       Run a full integration test cycle
```

We can add/remove documentation as needed to hide non user-facing targets.

This make target comes from [jwilm/alacritty](https://github.com/jwilm/alacritty/blob/v0.2.1/Makefile#L22).