### PR TITLE
Invert comparison when managing project network membership

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -193,7 +193,7 @@ resource "google_service_account_iam_member" "service_account_grant_to_group" {
   compute.networkUser role granted to GSuite group, APIs Service account, Project Service Account, and GKE Service Account on shared VPC
  *************************************************************************************/
 resource "google_project_iam_member" "controlling_group_vpc_membership" {
-  count = "${(var.shared_vpc != "" && (length(compact(var.shared_vpc_subnets)) == 0)) ? local.shared_vpc_users_length : 0}"
+  count = "${(var.shared_vpc != "" && (length(compact(var.shared_vpc_subnets)) > 0)) ? local.shared_vpc_users_length : 0}"
 
   project = "${var.shared_vpc}"
   role    = "roles/compute.networkUser"


### PR DESCRIPTION
An inverted comparison caused us to not add members to the
`roles/compute.networkUser` role when shared VPC subnets were supplied.
This commit fixes the error.

Thanks to @aaron-lane for improving the test-kitchen test coverage to catch this!