### PR TITLE
Use sed in cross-platform compatible manner

### DIFF
--- a/helpers/release-new-version.sh
+++ b/helpers/release-new-version.sh
@@ -30,7 +30,7 @@ fi
 
 echo -e "\nUpdating usage examples in README to use $NEW_RELEASE_NAME and commiting...\n"
 
-sed -i '' "s/$CURRENT_RELEASE_NAME/$NEW_RELEASE_NAME/g" README.md
+sed -i.bak "s/$CURRENT_RELEASE_NAME/$NEW_RELEASE_NAME/g" README.md && rm README.md.bak
 
 git checkout master && \
   git add README.md && \

--- a/helpers/release-new-version.sh
+++ b/helpers/release-new-version.sh
@@ -30,7 +30,7 @@ fi
 
 echo -e "\nUpdating usage examples in README to use $NEW_RELEASE_NAME and commiting...\n"
 
-sed -i.bak "s/$CURRENT_RELEASE_NAME/$NEW_RELEASE_NAME/g" README.md && rm README.md.bak
+sed -i.bak -e "s/$CURRENT_RELEASE_NAME/$NEW_RELEASE_NAME/g" README.md && rm README.md.bak
 
 git checkout master && \
   git add README.md && \

--- a/helpers/setup-sa.sh
+++ b/helpers/setup-sa.sh
@@ -162,17 +162,11 @@ if [[ ${BILLING_ACCOUNT:-} != "" ]]; then
   echo "Enabling the billing account..."
   gcloud beta billing accounts get-iam-policy $BILLING_ACCOUNT > policy-tmp-$$.yml
   unamestr=`uname`
-  if [ "$unamestr" = 'Darwin' ]; then
-    sed -i '' -e "/^etag:.*/i \\
+  if [ "$unamestr" = 'Darwin' || "$unamestr" = 'Linux' ]; then
+    sed -i.bak -e "/^etag:.*/i \\
 - members:\\
 \ \ - serviceAccount:${SA_ID}\\
-\ \ role: roles/billing.user" policy-tmp-$$.yml
-    gcloud beta billing accounts set-iam-policy $BILLING_ACCOUNT policy-tmp-$$.yml
-  elif [ "$unamestr" = 'Linux' ]; then
-    sed -i -e "/^etag:.*/i \\
-- members:\\
-\ \ - serviceAccount:${SA_ID}\\
-\ \ role: roles/billing.user" policy-tmp-$$.yml
+\ \ role: roles/billing.user" policy-tmp-$$.yml && rm policy-tmp-$$.yml.bak
     gcloud beta billing accounts set-iam-policy $BILLING_ACCOUNT policy-tmp-$$.yml
   else
     echo "Could not set roles/billing.user on service account $SERVICE_ACCOUNT.\

--- a/helpers/setup-sa.sh
+++ b/helpers/setup-sa.sh
@@ -162,7 +162,7 @@ if [[ ${BILLING_ACCOUNT:-} != "" ]]; then
   echo "Enabling the billing account..."
   gcloud beta billing accounts get-iam-policy $BILLING_ACCOUNT > policy-tmp-$$.yml
   unamestr=`uname`
-  if [ "$unamestr" = 'Darwin' || "$unamestr" = 'Linux' ]; then
+  if [ "$unamestr" = 'Darwin' -o "$unamestr" = 'Linux' ]; then
     sed -i.bak -e "/^etag:.*/i \\
 - members:\\
 \ \ - serviceAccount:${SA_ID}\\


### PR DESCRIPTION
sed on Linux-based systems does not understand `-i ''`.