### PR TITLE
Create shared VPC host project for integration tests

### DIFF
--- a/test/fixtures/shared/outputs.tf
+++ b/test/fixtures/shared/outputs.tf
@@ -56,7 +56,7 @@ output "sa_role" {
 }
 
 output "shared_vpc" {
-  value = "${var.shared_vpc}"
+  value = "${local.shared_vpc}"
 }
 
 output "usage_bucket_name" {

--- a/test/fixtures/shared/terraform.tfvars.example
+++ b/test/fixtures/shared/terraform.tfvars.example
@@ -28,16 +28,6 @@ credentials_path = "credentials.json"
 # The G Suite admin account to impersonate when managing G Suite groups and group membership
 gsuite_admin_account = "admin@example.com"
 
-# The Shared VPC host project.
-#
-# Example:
-#
-# ```
-# org_id=$(gcloud organizations list --format='get(name)')
-# gcloud compute shared-vpc organizations list-host-projects $org_id
-# ```
-shared_vpc = "host-vpc-project-id"
-
 # The folder ID where the project will be created.
 # Example source: `gcloud alpha resource-manager folders list --organization $(gcloud organizations list --format='get(name)')`
 # folder_id = "000000000000"

--- a/test/fixtures/shared/variables.tf
+++ b/test/fixtures/shared/variables.tf
@@ -47,10 +47,6 @@ variable "group_role" {
   default = "roles/viewer"
 }
 
-variable "shared_vpc" {
-  default = ""
-}
-
 variable "sa_role" {
   default = "roles/editor"
 }


### PR DESCRIPTION
In order to have fully isolated tests in CI we should create all
fixtures within the tests, including the shared VPC host and network.
This commit removes the `shared_vpc` variable from the test
configurations and creates an additional project instead.