### PR TITLE
Preconditions script is python3 only

### DIFF
--- a/scripts/preconditions.sh
+++ b/scripts/preconditions.sh
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if command -v python 1>/dev/null; then
+if command -v python3 1>/dev/null; then
     BASEDIR="$(dirname "$0")"
     SCRIPT="$BASEDIR/preconditions/preconditions.py"
     exec "$SCRIPT" "$@"
 else
-    echo "Unable to check project-factory preconditions: python executable not in PATH" 1>&2
+    echo "Unable to check project-factory preconditions: python3 executable not in PATH" 1>&2
 fi

--- a/scripts/preconditions/preconditions.py
+++ b/scripts/preconditions/preconditions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2018 Google LLC
 #


### PR DESCRIPTION
The preconditions script attempts to catch the FileNotFoundError
exception, which is only defined in Python3. This commit updates the
preconditions shell wrapper to search for python3 and updates the
preconditions script shebang accordingly.