### PR TITLE
Fix `check_terraform` make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,8 @@ check_golang: ## Lint Go source files
 	@source test/make.sh && golang
 
 .PHONY: check_terraform
-check_terraform:
-	@source ## Lint Terraform source files
+check_terraform: ## Lint Terraform source files
+	@source test/make.sh && check_terraform
 
 .PHONY: check_docker
 check_docker: ## Lint Dockerfiles


### PR DESCRIPTION
Commit ea33a35 introduced a typo to the `make check_terraform` target,
this commit fixes the error.