### PR TITLE
Only manage group if it is existent

### DIFF
--- a/modules/gsuite_enabled/main.tf
+++ b/modules/gsuite_enabled/main.tf
@@ -70,7 +70,7 @@ module "project-factory" {
   group_email                 = "${module.gsuite_group.email}"
   group_role                  = "${var.group_role}"
   lien                        = "${var.lien}"
-  manage_group                = "true"
+  manage_group                = "${var.group_name != "" || var.create_group ? "true" : "false"}"
   random_project_id           = "${var.random_project_id}"
   org_id                      = "${var.org_id}"
   name                        = "${var.name}"

--- a/modules/gsuite_enabled/main.tf
+++ b/modules/gsuite_enabled/main.tf
@@ -70,7 +70,7 @@ module "project-factory" {
   group_email                 = "${module.gsuite_group.email}"
   group_role                  = "${var.group_role}"
   lien                        = "${var.lien}"
-  manage_group                = "${var.group_name != "" || var.create_group ? "true" : "false"}"
+  manage_group                = "${var.group_name != "" || var.create_group}"
   random_project_id           = "${var.random_project_id}"
   org_id                      = "${var.org_id}"
   name                        = "${var.name}"


### PR DESCRIPTION
This commit patches gsuite_enabled to only manage a group when a name is
provided or the toggle to create a group is set.