### PR TITLE
Make Targets to Run Preconditions and Migrate Script Tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ DOCKER_ORG := gcr.io/cloud-foundation-cicd
 DOCKER_TAG_BASE_KITCHEN_TERRAFORM ?= 0.11.10_216.0.0_1.19.1_0.1.10
 DOCKER_REPO_BASE_KITCHEN_TERRAFORM := ${DOCKER_ORG}/cft/kitchen-terraform:${DOCKER_TAG_BASE_KITCHEN_TERRAFORM}
 
-all: check_shell check_python check_golang check_terraform check_docker check_base_files test_check_headers check_headers check_trailing_whitespace generate_docs ## Run all linters and update documentation
+all: check_shell check_python check_golang check_terraform check_docker check_base_files test_check_headers check_headers check_trailing_whitespace test_migrate test_preconditions generate_docs ## Run all linters, unit tests, and update documentation
 
 # The .PHONY directive tells make that this isn't a real target and so
 # the presence of a file named 'check_shell' won't cause this target to stop

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,16 @@ check_headers: ## Check that source files have appropriate boilerplate
 	@echo "Checking file headers"
 	@python test/verify_boilerplate.py
 
+.PHONY: test_migrate
+test_migrate:
+	@echo "Testing migrate script"
+	@python test/helpers/test_migrate.py
+
+.PHONY: test_preconditions
+test_preconditions:
+	@echo "Testing preconditions script"
+	@python test/scripts/preconditions/test_preconditions.py
+
 # Integration tests
 .PHONY: test_integration
 test_integration: ## Run integration tests

--- a/test/scripts/preconditions/test_preconditions.py
+++ b/test/scripts/preconditions/test_preconditions.py
@@ -21,7 +21,7 @@ sys.path.append(
     os.path.abspath(
         os.path.join(
             os.path.dirname(__file__),
-            '../../../scripts/preconditions')))
+            '../../../modules/core_project_factory/scripts/preconditions')))
 
 import preconditions  # noqa: E402
 


### PR DESCRIPTION
These are newly added tests. Make targets are added to run them and those targets have been added as dependencies to the `all` target. Being dependencies of `all` will make them run as part of the `lint-tests` job of the project-factory Concourse CI pipeline.

Something to note about these tests is that upon failure, they will cause Make to exit as opposed to proceeding with running subsequent target dependencies. This is different than most of the others, but I would argue its behavior is preferable as it will cause tests to fail faster.

As a followup, I intend to update the project-factory Concourse pipeline so that it installs the necessary Python package dependencies before test execution.