### PR TITLE
Move CI configuration logic to script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,12 +85,7 @@ test_unit: test_migrate test_preconditions
 # Integration tests
 .PHONY: test_integration
 test_integration: ## Run integration tests
-	bundle install
-	bundle exec kitchen create
-	bundle exec kitchen converge
-	bundle exec kitchen converge
-	bundle exec kitchen verify
-	bundle exec kitchen destroy
+	test/ci_integration.sh
 
 .PHONY: generate_docs
 generate_docs: ## Update README documentation for Terraform variables and outputs
@@ -104,17 +99,29 @@ release-new-version:
 .PHONY: docker_run
 docker_run: ## Launch a shell within the Docker test environment
 	docker run --rm -it \
-		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
-		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
+		-e BILLING_ACCOUNT_ID  \
+		-e SERVICE_ACCOUNT_JSON \
+		-e DOMAIN \
+		-e FOLDER_ID \
+		-e GROUP_NAME \
+		-e ADMIN_ACCOUNT_EMAIL \
+		-e ORG_ID \
+		-e PROJECT_ID \
 		-v $(CURDIR):/cft/workdir \
 		${DOCKER_REPO_BASE_KITCHEN_TERRAFORM} \
-		/bin/bash
+		/bin/bash -c 'source test/ci_integration.sh && setup_environment && exec /bin/bash'
 
 .PHONY: docker_create
 docker_create: ## Run `kitchen create` within the Docker test environment
 	docker run --rm -it \
-		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
-		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
+		-e BILLING_ACCOUNT_ID  \
+		-e SERVICE_ACCOUNT_JSON \
+		-e DOMAIN \
+		-e FOLDER_ID \
+		-e GROUP_NAME \
+		-e ADMIN_ACCOUNT_EMAIL \
+		-e ORG_ID \
+		-e PROJECT_ID \
 		-v $(CURDIR):/cft/workdir \
 		${DOCKER_REPO_BASE_KITCHEN_TERRAFORM} \
 		/bin/bash -c "bundle exec kitchen create"
@@ -122,8 +129,14 @@ docker_create: ## Run `kitchen create` within the Docker test environment
 .PHONY: docker_converge
 docker_converge: ## Run `kitchen converge` within the Docker test environment
 	docker run --rm -it \
-		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
-		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
+		-e BILLING_ACCOUNT_ID  \
+		-e SERVICE_ACCOUNT_JSON \
+		-e DOMAIN \
+		-e FOLDER_ID \
+		-e GROUP_NAME \
+		-e ADMIN_ACCOUNT_EMAIL \
+		-e ORG_ID \
+		-e PROJECT_ID \
 		-v $(CURDIR):/cft/workdir \
 		${DOCKER_REPO_BASE_KITCHEN_TERRAFORM} \
 		/bin/bash -c "bundle exec kitchen converge && bundle exec kitchen converge"
@@ -131,8 +144,14 @@ docker_converge: ## Run `kitchen converge` within the Docker test environment
 .PHONY: docker_verify
 docker_verify: ## Run `kitchen verify` within the Docker test environment
 	docker run --rm -it \
-		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
-		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
+		-e BILLING_ACCOUNT_ID  \
+		-e SERVICE_ACCOUNT_JSON \
+		-e DOMAIN \
+		-e FOLDER_ID \
+		-e GROUP_NAME \
+		-e ADMIN_ACCOUNT_EMAIL \
+		-e ORG_ID \
+		-e PROJECT_ID \
 		-v $(CURDIR):/cft/workdir \
 		${DOCKER_REPO_BASE_KITCHEN_TERRAFORM} \
 		/bin/bash -c "bundle exec kitchen verify"
@@ -140,15 +159,32 @@ docker_verify: ## Run `kitchen verify` within the Docker test environment
 .PHONY: docker_destroy
 docker_destroy: ## Run `kitchen destroy` within the Docker test environment
 	docker run --rm -it \
-		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
-		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
+		-e BILLING_ACCOUNT_ID  \
+		-e SERVICE_ACCOUNT_JSON \
+		-e DOMAIN \
+		-e FOLDER_ID \
+		-e GROUP_NAME \
+		-e ADMIN_ACCOUNT_EMAIL \
+		-e ORG_ID \
+		-e PROJECT_ID \
 		-v $(CURDIR):/cft/workdir \
 		${DOCKER_REPO_BASE_KITCHEN_TERRAFORM} \
 		/bin/bash -c "bundle exec kitchen destroy"
 
 .PHONY: test_integration_docker
-test_integration_docker: docker_create docker_converge docker_verify docker_destroy ## Run a full integration test cycle
-	@echo "Running test-kitchen tests in docker"
+test_integration_docker:
+	docker run --rm -it \
+		-e BILLING_ACCOUNT_ID  \
+		-e SERVICE_ACCOUNT_JSON \
+		-e DOMAIN \
+		-e FOLDER_ID \
+		-e GROUP_NAME \
+		-e ADMIN_ACCOUNT_EMAIL \
+		-e ORG_ID \
+		-e PROJECT_ID \
+		-v $(CURDIR):/cft/workdir \
+		${DOCKER_REPO_BASE_KITCHEN_TERRAFORM} \
+		test/ci_integration.sh
 
 help: ## Prints help for targets with comments
 	@grep -E '^[a-zA-Z._-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/test/ci_integration.sh
+++ b/test/ci_integration.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Always clean up.
+DELETE_AT_EXIT="$(mktemp -d)"
+finish() {
+  echo 'BEGIN: finish() trap handler' >&2
+  kitchen destroy
+  [[ -d "${DELETE_AT_EXIT}" ]] && rm -rf "${DELETE_AT_EXIT}"
+  echo 'END: finish() trap handler' >&2
+}
+
+# Map the input parameters provided by Concourse CI, or whatever mechanism is
+# running the tests to Terraform input variables.  Also setup credentials for
+# use with kitchen-terraform, inspec, and gcloud.
+setup_environment() {
+  local tmpfile
+  tmpfile="$(mktemp)"
+  echo "${SERVICE_ACCOUNT_JSON}" > "${tmpfile}"
+
+  # gcloud variables
+  export CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE="${tmpfile}"
+  # Application default credentials (Terraform google provider and inspec-gcp)
+  export GOOGLE_APPLICATION_CREDENTIALS="${tmpfile}"
+
+  # Terraform variables
+  export TF_VAR_billing_account="${BILLING_ACCOUNT_ID}"
+  export TF_VAR_credentials_path="${CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE}"
+  export TF_VAR_domain="${DOMAIN}"
+  export TF_VAR_folder_id="${FOLDER_ID}"
+  export TF_VAR_group_name="${GROUP_NAME}"
+  export TF_VAR_gsuite_admin_account="${ADMIN_ACCOUNT_EMAIL}"
+  export TF_VAR_org_id="${ORG_ID}"
+  export TF_VAR_shared_vpc="${PROJECT_ID}"
+}
+
+main() {
+  set -eu
+  # Setup trap handler to auto-cleanup
+  export TMPDIR="${DELETE_AT_EXIT}"
+  trap finish EXIT
+
+  # Setup environment variables
+  setup_environment
+  set -x
+
+  # Execute the test lifecycle
+  kitchen create
+  kitchen converge
+  kitchen converge
+  kitchen verify
+}
+
+# if script is being executed and not sourced.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi


### PR DESCRIPTION
This commit extracts the CI setup logic into a shell script in this repository, and updates the Make targets to pass around the correct environment variables. This change allows us to more closely simulate how CI works, and allows us to iterate on the CI workflow in pull requests rather than having to manage everything within the pipeline definition.