### PR TITLE
Fix a race condition when creating a new G Suite group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 
 # Python
 *.pyc
+# Python virtualenv
+venv
 
 # Emacs save files
 *~

--- a/modules/core_project_factory/main.tf
+++ b/modules/core_project_factory/main.tf
@@ -137,6 +137,8 @@ resource "google_compute_shared_vpc_service_project" "shared_vpc_attachment" {
  *****************************************/
 data "google_compute_default_service_account" "default" {
   project = "${google_project.main.id}"
+
+  depends_on = ["google_project_service.project_services"]
 }
 
 /******************************************

--- a/modules/gsuite_enabled/main.tf
+++ b/modules/gsuite_enabled/main.tf
@@ -27,8 +27,6 @@ resource "gsuite_group_member" "service_account_sa_group_member" {
   group = "${var.sa_group}"
   email = "${module.project-factory.service_account_email}"
   role  = "MEMBER"
-
-  depends_on = ["module.project-factory"]
 }
 
 /*****************************************
@@ -40,17 +38,7 @@ module "gsuite_group" {
   domain = "${var.domain}"
   name   = "${local.group_name}"
   org_id = "${var.org_id}"
-}
-
-/******************************************
-  Gsuite Group Configuration
- *****************************************/
-resource "gsuite_group" "group" {
-  count = "${var.create_group ? 1 : 0}"
-
-  description = "${var.name} project group"
-  email       = "${module.gsuite_group.email}"
-  name        = "${local.group_name}"
+  create_group = "${var.create_group}"
 }
 
 /***********************************************

--- a/modules/gsuite_group/main.tf
+++ b/modules/gsuite_group/main.tf
@@ -25,3 +25,14 @@ locals {
 data "google_organization" "org" {
   organization = "${var.org_id}"
 }
+
+/******************************************
+  Gsuite Group Configuration
+ *****************************************/
+resource "gsuite_group" "group" {
+  count = "${var.create_group ? 1 : 0}"
+
+  description = "${var.name} project group"
+  email       = "${local.email}"
+  name        = "${var.name}"
+}

--- a/modules/gsuite_group/outputs.tf
+++ b/modules/gsuite_group/outputs.tf
@@ -21,5 +21,5 @@ output "domain" {
 
 output "email" {
   description = "The email address of the group."
-  value       = "${local.email}"
+  value       = "${element(compact(concat(gsuite_group.group.*.email, list(local.email))), 0)}"
 }

--- a/modules/gsuite_group/variables.tf
+++ b/modules/gsuite_group/variables.tf
@@ -26,3 +26,8 @@ variable "name" {
 variable "org_id" {
   description = "The organization ID."
 }
+
+variable "create_group" {
+  description = "Whether to create the group or not"
+  default     = "false"
+}


### PR DESCRIPTION
When a new G Suite group is created to manage a project, `core_project_factory` would attempt to assign the group IAM permissions before the group was finished being created by the `gsuite_enabled` module. To fix this condition, an implicit dependency was added to the Terraform using the email attribute from the `gsuite_group` resource.

Also, the `google_compute_default_service_account` resource depends on the Compute Engine API being enabled so it is possible for the fetch of the data resource to fail because it attempts to query the Compute Engine API before it is fully enabled. Adding an explicit dependency on the services being enabled fixes this issue.