### PR TITLE
Fix shared VPC IAM bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ determining that location is as follows:
 | lien | Add a lien on the project to prevent accidental deletion | string | `"false"` | no |
 | name | The name for the project | string | n/a | yes |
 | org\_id | The organization ID. | string | n/a | yes |
-| random\_project\_id | Enables project random id generation | string | `"false"` | no |
+| project\_id | If provided, the project uses the given project ID. Mutually exclusive with random_project_id being true. | string | `""` | no |
+| random\_project\_id | Enables project random id generation. Mutually exclusive with project_id being non-empty. | string | `"false"` | no |
 | sa\_role | A role to give the default Service Account for the project (defaults to none) | string | `""` | no |
 | shared\_vpc | The ID of the host project which hosts the shared VPC | string | `""` | no |
 | shared\_vpc\_subnets | List of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id) | list | `<list>` | no |
@@ -137,6 +138,7 @@ determining that location is as follows:
 | project\_bucket\_self\_link | Project's bucket selfLink |
 | project\_bucket\_url | Project's bucket url |
 | project\_id |  |
+| project\_name |  |
 | project\_number |  |
 | service\_account\_display\_name | The display name of the default service account |
 | service\_account\_email | The email of the default service account |

--- a/README.md
+++ b/README.md
@@ -86,6 +86,20 @@ The roles granted are specifically:
   - `compute.networkUser` on host project or specified subnets
   - `storage.admin` on `bucket_name` GCS bucket
 
+### Shared VPC subnets and IAM permissions
+
+A service project's access to shared VPC networks is controlled via the
+`roles/compute.networkUser` role and the location to where that role is
+assigned. If that role is assigned to the shared VPC host project, then the
+service project will have access to **all** shared VPC subnetworks. If that role
+is assigned to individual subnetworks, then the service project will have
+access to only the subnetworks on which that role was assigned. The logic for
+determining that location is as follows:
+
+1. If `var.shared_vpc` and `var.shared_vpc_subnets` are not set then the `compute.networkUser` role is not assigned
+1. If `var.shared_vpc` is set but no subnetworks are provided via `var.shared_vpc_subnets` then the `compute.networkUser` role is assigned at the host project and the service project will have access to all shared VPC subnetworks
+1. If `var.shared_vpc` is set and `var.shared_vpc_subnets` contains an array of subnetworks then the `compute.networkUser` role is assigned to each subnetwork in the array
+
 [^]: (autogen_docs_start)
 
 ## Inputs

--- a/modules/core_project_factory/README.md
+++ b/modules/core_project_factory/README.md
@@ -21,7 +21,8 @@
 | manage\_group | A toggle to indicate if a G Suite group should be managed. | string | `"false"` | no |
 | name | The name for the project | string | n/a | yes |
 | org\_id | The organization ID. | string | n/a | yes |
-| random\_project\_id | Enables project random id generation | string | `"false"` | no |
+| project\_id | If provided, the project uses the given project ID. Mutually exclusive with random_project_id being true. | string | `""` | no |
+| random\_project\_id | Enables project random id generation. Mutually exclusive with project_id being non-empty. | string | `"false"` | no |
 | sa\_role | A role to give the default Service Account for the project (defaults to none) | string | `""` | no |
 | shared\_vpc | The ID of the host project which hosts the shared VPC | string | `""` | no |
 | shared\_vpc\_subnets | List of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id) | list | `<list>` | no |
@@ -38,6 +39,7 @@
 | project\_bucket\_self\_link | Project's bucket selfLink |
 | project\_bucket\_url | Project's bucket url |
 | project\_id |  |
+| project\_name |  |
 | project\_number |  |
 | service\_account\_display\_name | The display name of the default service account |
 | service\_account\_email | The email of the default service account |

--- a/modules/core_project_factory/main.tf
+++ b/modules/core_project_factory/main.tf
@@ -198,7 +198,7 @@ resource "google_service_account_iam_member" "service_account_grant_to_group" {
   Account on shared VPC
  *****************************************************************************************************************/
 resource "google_project_iam_member" "controlling_group_vpc_membership" {
-  count = "${(var.shared_vpc != "" && (length(compact(var.shared_vpc_subnets)) > 0)) ? local.shared_vpc_users_length : 0}"
+  count = "${(var.shared_vpc != "" && (length(compact(var.shared_vpc_subnets)) == 0)) ? local.shared_vpc_users_length : 0}"
 
   project = "${var.shared_vpc}"
   role    = "roles/compute.networkUser"

--- a/modules/gsuite_enabled/README.md
+++ b/modules/gsuite_enabled/README.md
@@ -76,7 +76,8 @@ The roles granted are specifically:
 | lien | Add a lien on the project to prevent accidental deletion | string | `"false"` | no |
 | name | The name for the project | string | n/a | yes |
 | org\_id | The organization ID. | string | n/a | yes |
-| random\_project\_id | Enables project random id generation | string | `"false"` | no |
+| project\_id | If provided, the project uses the given project ID. Mutually exclusive with random_project_id being true. | string | `""` | no |
+| random\_project\_id | Enables project random id generation. Mutually exclusive with project_id being non-empty. | string | `"false"` | no |
 | sa\_group | A GSuite group to place the default Service Account for the project in | string | `""` | no |
 | sa\_role | A role to give the default Service Account for the project (defaults to none) | string | `""` | no |
 | shared\_vpc | The ID of the host project which hosts the shared VPC | string | `""` | no |
@@ -93,6 +94,7 @@ The roles granted are specifically:
 | project\_bucket\_self\_link | Project's bucket selfLink |
 | project\_bucket\_url | Project's bucket url |
 | project\_id |  |
+| project\_name |  |
 | project\_number |  |
 | service\_account\_display\_name | The display name of the default service account |
 | service\_account\_email | The email of the default service account |

--- a/test/fixtures/full/README.md
+++ b/test/fixtures/full/README.md
@@ -32,6 +32,7 @@
 | group\_role |  |
 | gsuite\_admin\_account |  |
 | project\_id |  |
+| project\_name |  |
 | project\_number |  |
 | region |  |
 | sa\_role |  |

--- a/test/fixtures/minimal/README.md
+++ b/test/fixtures/minimal/README.md
@@ -30,6 +30,7 @@
 | group\_role |  |
 | gsuite\_admin\_account |  |
 | project\_id |  |
+| project\_name |  |
 | project\_number |  |
 | region |  |
 | sa\_role |  |

--- a/test/integration/full/controls/shared-vpc.rb
+++ b/test/integration/full/controls/shared-vpc.rb
@@ -43,26 +43,26 @@ control 'project-factory-shared-vpc' do
     end
 
     describe "roles/compute.networkUser" do
-      it "includes the project service account in the roles/compute.networkUser IAM binding" do
-        expect(bindings).to include(
+      it "does not include the project service account in the roles/compute.networkUser IAM binding" do
+        expect(bindings).not_to include(
           members: including("serviceAccount:#{service_account_email}"),
           role: "roles/compute.networkUser",
         )
       end
 
-      it "includes the group email in the roles/compute.networkUser IAM binding" do
+      it "does not include the group email in the roles/compute.networkUser IAM binding" do
         if group_email.nil? || group_email.empty?
           pending "group_email not defined - skipping test"
         end
 
-        expect(bindings).to include(
+        expect(bindings).not_to include(
           members: including("group:#{group_email}"),
           role: "roles/compute.networkUser",
         )
       end
 
-      it "includes the GKE service account in the roles/compute.networkUser IAM binding" do
-        expect(bindings).to include(
+      it "does not include the GKE service account in the roles/compute.networkUser IAM binding" do
+        expect(bindings).not_to include(
           members: including(
             "serviceAccount:service-#{project_number}@container-engine-robot.iam.gserviceaccount.com"
           ),


### PR DESCRIPTION
This commit addresses issue #97
(https://github.com/terraform-google-modules/terraform-google-project-factory/issues/97)
and updates the logic around IAM bindings with regard to shared VPC
subnets. The logic is as follows:

1. If `var.shared_vpc` and `var.shared_vpc_subnets` are empty no
   bindings are mad
2. If `var.shared_vpc` is set but no subnets are provided with
   `var.shared_vpc_subnets` then the IAM bindings are set at the Host
   Project
3. If `var.shared_vpc` is set and `var.shared_vpc_subnets` contains
   subnets then the IAM bindings are granted on the subnetworks
   themselve

This commit updates the logic used to calculate the Host Project
bindings based on scenario 3 above. The tests have also been modified to
ensure that those bindings AREN'T set.