### PR TITLE
Update CHANGELOG.md for v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Extending the adopted spec, each change should have a link to its corresponding pull request appended.
 
+## [Unreleased]
+
 ## [2.1.0] - 2019-03-11
 
 ### ADDED
@@ -89,7 +91,8 @@ Extending the adopted spec, each change should have a link to its corresponding 
 ### ADDED
 - This is the initial release of the Project Factory Module.
 
-[Unreleased]: https://github.com/terraform-google-modules/terraform-google-project-factory/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/terraform-google-modules/terraform-google-project-factory/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/terraform-google-modules/terraform-google-project-factory/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/terraform-google-modules/terraform-google-project-factory/compare/v1.2.0...v2.0.0
 [1.2.0]: https://github.com/terraform-google-modules/terraform-google-project-factory/compare/v1.1.2...v1.2.0
 [1.1.2]: https://github.com/terraform-google-modules/terraform-google-project-factory/compare/v1.1.1...v1.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Extending the adopted spec, each change should have a link to its corresponding pull request appended.
 
+## [2.1.0] - 2019-03-11
+
+### ADDED
+
+- The optional `project_id` variable enables a disconnect between the project name and the project ID. [#154]  
+
+### FIXED
+
+- Shared VPC IAM bindings. [#164]
+
 ## [2.0.0] - 2019-03-05
 2.0.0 is a major backwards incompatible release. See the [upgrade guide](./docs/upgrading_to_project_factory_v2.0.md) for details.
 
 ### ADDED
 
 - Added separate App Engine module. [#144]
+- Support for v2.X of the Google provider and the Google Beta provider.
 
 ### REMOVED
 
@@ -91,6 +102,8 @@ Extending the adopted spec, each change should have a link to its corresponding 
 [0.2.1]: https://github.com/terraform-google-modules/terraform-google-project-factory/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/terraform-google-modules/terraform-google-project-factory/compare/v0.1.0...v0.2.0
 
+[#164]: https://github.com/terraform-google-modules/terraform-google-project-factory/pull/164
+[#154]: https://github.com/terraform-google-modules/terraform-google-project-factory/pull/154
 [#153]: https://github.com/terraform-google-modules/terraform-google-project-factory/pull/153
 [#147]: https://github.com/terraform-google-modules/terraform-google-project-factory/pull/147
 [#144]: https://github.com/terraform-google-modules/terraform-google-project-factory/pull/144

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Extending the adopted spec, each change should have a link to its corresponding 
 
 ### ADDED
 
-- The optional `project_id` variable enables a disconnect between the project name and the project ID. [#154]  
+- The optional `project_id` variable enables a disconnect between the project name and the project ID. [#154]
 
 ### FIXED
 


### PR DESCRIPTION
This branch adds the CHANGELOG entry for v2.1.0. It also notes that v2.0.0 introduced support for v2 of the Google Terraform providers.