### PR TITLE
Add test for shared VPC IAM behavior

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -38,3 +38,20 @@ suites:
       name: terraform
       command_timeout: 1800
       root_module_directory: test/fixtures/minimal
+
+  - name: "shared_vpc_no_subnets"
+    driver:
+      name: "terraform"
+      command_timeout: 1800
+      root_module_directory: test/fixtures/shared_vpc_no_subnets/
+    verifier:
+      name: terraform
+      systems:
+        - name: inspec-gcp
+          backend: gcp
+          controls:
+            - gcp
+        - name: local
+          backend: local
+          controls:
+            - gcloud

--- a/test/fixtures/full/extra_outputs.tf
+++ b/test/fixtures/full/extra_outputs.tf
@@ -17,3 +17,11 @@
 output "extra_service_account_email" {
   value = "${google_service_account.extra_service_account.email}"
 }
+
+output "shared_vpc_subnet_name" {
+  value = "${local.shared_vpc_subnet_name}"
+}
+
+output "shared_vpc_subnet_region" {
+  value = "${local.shared_vpc_subnet_region}"
+}

--- a/test/fixtures/full/main.tf
+++ b/test/fixtures/full/main.tf
@@ -37,8 +37,10 @@ provider "gsuite" {
 }
 
 locals {
-  shared_vpc_subnets = ["projects/${var.shared_vpc}/regions/${module.vpc.subnets_regions[0]}/subnetworks/${module.vpc.subnets_names[0]}"]
-  subnet_name        = "pf-test-subnet-${var.random_string_for_testing}"
+  subnet_name              = "pf-test-subnet-${var.random_string_for_testing}"
+  shared_vpc_subnet_name   = "${module.vpc.subnets_names[0]}"
+  shared_vpc_subnet_region = "${module.vpc.subnets_regions[0]}"
+  shared_vpc_subnets       = ["projects/${var.shared_vpc}/regions/${local.shared_vpc_subnet_region}/subnetworks/${local.shared_vpc_subnet_name}"]
 }
 
 module "vpc" {

--- a/test/fixtures/shared_vpc_no_subnets/extra_variables.tf
+++ b/test/fixtures/shared_vpc_no_subnets/extra_variables.tf
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "credentials_path" {
+  description = "Path to a service account credentials file with rights to run the Project Factory."
+  default     = ""
+}

--- a/test/fixtures/shared_vpc_no_subnets/main.tf
+++ b/test/fixtures/shared_vpc_no_subnets/main.tf
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+provider "google" {
+  version = "~> 2.1"
+}
+
+provider "google-beta" {
+  version = "~> 2.1"
+}
+
+provider "gsuite" {
+  credentials             = "${file(var.credentials_path)}"
+  impersonated_user_email = "${var.gsuite_admin_account}"
+
+  oauth_scopes = [
+    "https://www.googleapis.com/auth/admin.directory.group",
+    "https://www.googleapis.com/auth/admin.directory.group.member",
+  ]
+
+  version = "~> 0.1.9"
+}
+
+module "project-factory" {
+  source = "../../../modules/gsuite_enabled"
+
+  name              = "pf-ci-test-nosubnets-${var.random_string_for_testing}"
+  project_id        = "pf-ci-test-nosubnets-${var.random_string_for_testing}"
+  random_project_id = "false"
+  domain            = "${var.domain}"
+  org_id            = "${var.org_id}"
+  folder_id         = "${var.folder_id}"
+  billing_account   = "${var.billing_account}"
+  create_group      = "true"
+  group_role        = "${var.group_role}"
+  group_name        = "pf-secondgroup-${var.random_string_for_testing}"
+  shared_vpc        = "${var.shared_vpc}"
+  credentials_path  = "${var.credentials_path}"
+
+  activate_apis = [
+    "compute.googleapis.com",
+    "container.googleapis.com",
+  ]
+
+  disable_services_on_destroy = "false"
+}

--- a/test/fixtures/shared_vpc_no_subnets/outputs.tf
+++ b/test/fixtures/shared_vpc_no_subnets/outputs.tf
@@ -1,0 +1,1 @@
+../shared/outputs.tf

--- a/test/fixtures/shared_vpc_no_subnets/variables.tf
+++ b/test/fixtures/shared_vpc_no_subnets/variables.tf
@@ -1,0 +1,1 @@
+../shared/variables.tf

--- a/test/integration/full/controls/shared-vpc.rb
+++ b/test/integration/full/controls/shared-vpc.rb
@@ -18,6 +18,8 @@ project_id                  = attribute('project_id')
 project_number              = attribute('project_number')
 service_account_email       = attribute('service_account_email')
 shared_vpc                  = attribute('shared_vpc')
+shared_vpc_subnet_name      = attribute('shared_vpc_subnet_name')
+shared_vpc_subnet_region    = attribute('shared_vpc_subnet_region')
 
 control 'project-factory-shared-vpc' do
   title "Project Factory shared VPC"
@@ -83,6 +85,32 @@ control 'project-factory-shared-vpc' do
         members: including("serviceAccount:service-#{project_number}@container-engine-robot.iam.gserviceaccount.com"),
         role: "roles/container.hostServiceAgentUser",
       )
+    end
+  end
+
+  describe command("gcloud beta compute networks subnets get-iam-policy #{shared_vpc_subnet_name} --region #{shared_vpc_subnet_region} --project #{shared_vpc} --format=json") do
+    its('exit_status') { should eq 0 }
+    its('stderr') { should eq '' }
+
+    let(:bindings) do
+      if subject.exit_status == 0
+        JSON.parse(subject.stdout, symbolize_names: true)[:bindings]
+      else
+        []
+      end
+    end
+
+    describe "roles/compute.networkUser" do
+      it "includes the group email in the roles/compute.networkUser IAM binding" do
+        if group_email.nil? || group_email.empty?
+          pending "group_email not defined - skipping test"
+        end
+
+        expect(bindings).to include(
+          members: including("group:#{group_email}"),
+          role: "roles/compute.networkUser",
+        )
+      end
     end
   end
 end

--- a/test/integration/full/inspec.yml
+++ b/test/integration/full/inspec.yml
@@ -52,3 +52,11 @@ attributes:
   - name: domain
     type: string
     required: true
+
+  - name: shared_vpc_subnet_name
+    type: string
+    required: true
+
+  - name: shared_vpc_subnet_region
+    type: string
+    required: true

--- a/test/integration/shared_vpc_no_subnets/controls/gcloud.rb
+++ b/test/integration/shared_vpc_no_subnets/controls/gcloud.rb
@@ -1,0 +1,67 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+group_email                 = attribute('group_email')
+project_id                  = attribute('project_id')
+project_number              = attribute('project_number')
+service_account_email       = attribute('service_account_email')
+shared_vpc                  = attribute('shared_vpc')
+
+control 'project-factory-shared-vpc' do
+  title "Project Factory shared VPC"
+
+  describe command("gcloud compute shared-vpc get-host-project #{project_id} --format='get(name)'") do
+    its('exit_status') { should eq 0 }
+    its('stderr') { should eq '' }
+    its('stdout.strip') { should eq shared_vpc }
+  end
+
+  describe command("gcloud projects get-iam-policy #{shared_vpc} --format=json") do
+    its('exit_status') { should eq 0 }
+    its('stderr') { should eq '' }
+
+    let(:bindings) do
+      if subject.exit_status == 0
+        JSON.parse(subject.stdout, symbolize_names: true)[:bindings]
+      else
+        []
+      end
+    end
+
+    describe "roles/compute.networkUser" do
+      it "includes the project service account in the roles/compute.networkUser IAM binding" do
+        expect(bindings).to include(
+          members: including("serviceAccount:#{service_account_email}"),
+          role: "roles/compute.networkUser",
+        )
+      end
+
+      it "includes the group email in the roles/compute.networkUser IAM binding" do
+        expect(bindings).to include(
+          members: including("group:#{group_email}"),
+          role: "roles/compute.networkUser",
+        )
+      end
+
+      it "includes the GKE service account in the roles/compute.networkUser IAM binding" do
+        expect(bindings).to include(
+          members: including(
+            "serviceAccount:service-#{project_number}@container-engine-robot.iam.gserviceaccount.com"
+          ),
+          role: "roles/compute.networkUser",
+        )
+      end
+    end
+  end
+end

--- a/test/integration/shared_vpc_no_subnets/controls/gcp.rb
+++ b/test/integration/shared_vpc_no_subnets/controls/gcp.rb
@@ -1,0 +1,49 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+group_email = attribute('group_email')
+shared_vpc  = attribute('shared_vpc')
+
+control "gcp" do
+  # The shared_vpc_no_subnets scenario is testing to ensure that
+  # compute.networkUser bindings are set at the shared VPC host project level
+  # and aren't set at the subnetwork level. The only way to be sure that
+  # subnetwork bindings haven't been created (because a subnetwork was not
+  # specified) is to loop through all subnetworks in all regions and ensure
+  # there aren't any bindings set for the group being tested
+  google_compute_regions(
+    project: shared_vpc
+  ).region_names.each do |region|
+    google_compute_subnetworks(
+      project: shared_vpc,
+      region:  region,
+    ).subnetwork_names.each do |subnetwork_name|
+      describe "IAM bindings for subnetwork #{subnetwork_name} in region #{region}" do
+        let(:bindings) do
+          output = %x{gcloud beta compute networks subnets get-iam-policy #{subnetwork_name} --region #{region} --project #{shared_vpc} --format=json}
+          JSON.parse(output, symbolize_names: true)[:bindings]
+        end
+
+        it "do not include #{group_email} in the roles/compute.networkUser IAM binding" do
+          unless bindings.nil?
+            expect(bindings).not_to include(
+              members: including("group:#{group_email}"),
+              role: "roles/compute.networkUser",
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/integration/shared_vpc_no_subnets/inspec.yml
+++ b/test/integration/shared_vpc_no_subnets/inspec.yml
@@ -1,0 +1,37 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: shared_vpc_no_subnets
+depends:
+  - name: inspec-gcp
+    git: https://github.com/inspec/inspec-gcp.git
+    version: ~> 0.9.0
+attributes:
+  - name: project_id
+    required: true
+    type: string
+
+  - name: project_number
+    required: true
+    type: string
+
+  - name: service_account_email
+    required: true
+    type: string
+
+  - name: shared_vpc
+    required: true
+
+  - name: group_email
+    required: true


### PR DESCRIPTION
This commit adds tests surrounding the shared VPC IAM behavior.
Specifically, we're testing whether the `compute.networkUser` role is
added to the Host Project if `var.shared_vpc` is passed but
`var.shared_vpc_subnets` is not.