### PR TITLE
Refactor tests for randomized names

### DIFF
--- a/test/ci_integration.sh
+++ b/test/ci_integration.sh
@@ -45,6 +45,8 @@ setup_environment() {
   export TF_VAR_gsuite_admin_account="${ADMIN_ACCOUNT_EMAIL}"
   export TF_VAR_org_id="${ORG_ID}"
   export TF_VAR_shared_vpc="${PROJECT_ID}"
+  TF_VAR_random_string_for_testing="${RANDOM_STRING_FOR_TESTING:-$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 5 | head -n 1)}"
+  export TF_VAR_random_string_for_testing
 }
 
 main() {

--- a/test/fixtures/full/main.tf
+++ b/test/fixtures/full/main.tf
@@ -38,18 +38,13 @@ provider "gsuite" {
 
 locals {
   shared_vpc_subnets = ["projects/${var.shared_vpc}/regions/${module.vpc.subnets_regions[0]}/subnetworks/${module.vpc.subnets_names[0]}"]
-}
-
-resource "random_string" "suffix" {
-  length  = 8
-  special = false
-  upper   = false
+  subnet_name        = "pf-test-subnet-${var.random_string_for_testing}"
 }
 
 module "vpc" {
   source       = "terraform-google-modules/network/google"
   version      = "~> 0.4.0"
-  network_name = "pf-test-int-full-${random_string.suffix.result}"
+  network_name = "pf-test-int-full-${var.random_string_for_testing}"
   project_id   = "${var.shared_vpc}"
 
   # The provided project must already be a Shared VPC host
@@ -57,16 +52,16 @@ module "vpc" {
 
   subnets = [
     {
-      subnet_name   = "pf-test-subnet-01"
+      subnet_name   = "${local.subnet_name}"
       subnet_ip     = "10.10.10.0/24"
       subnet_region = "us-east4"
     },
   ]
 
   secondary_ranges = {
-    pf-test-subnet-01 = [
+    "${local.subnet_name}" = [
       {
-        range_name    = "pf-test-subnet-01-secondary"
+        range_name    = "${local.subnet_name}-secondary"
         ip_cidr_range = "192.168.64.0/24"
       },
     ]
@@ -76,9 +71,9 @@ module "vpc" {
 module "project-factory" {
   source = "../../../modules/gsuite_enabled"
 
-  name              = "pf-ci-test-full-name-${random_string.suffix.result}"
+  name              = "pf-ci-test-full-name-${var.random_string_for_testing}"
   random_project_id = "false"
-  project_id        = "pf-ci-test-full-id-${random_string.suffix.result}"
+  project_id        = "pf-ci-test-full-id-${var.random_string_for_testing}"
 
   domain              = "${var.domain}"
   org_id              = "${var.org_id}"

--- a/test/fixtures/minimal/main.tf
+++ b/test/fixtures/minimal/main.tf
@@ -22,16 +22,10 @@ provider "google-beta" {
   version = "~> 2.1"
 }
 
-resource "random_string" "suffix" {
-  length  = 5
-  special = false
-  upper   = false
-}
-
 module "project-factory" {
   source = "../../../"
 
-  name              = "pf-ci-test-minimal-${random_string.suffix.result}"
+  name              = "pf-ci-test-minimal-${var.random_string_for_testing}"
   random_project_id = true
   domain            = "${var.domain}"
   org_id            = "${var.org_id}"

--- a/test/fixtures/shared/variables.tf
+++ b/test/fixtures/shared/variables.tf
@@ -61,3 +61,7 @@ variable "region" {
 }
 
 variable "gsuite_admin_account" {}
+
+variable "random_string_for_testing" {
+  description = "A random string of characters to be appended to resource names to ensure uniqueness"
+}


### PR DESCRIPTION
Without this commit the integration test fixtures will create VPC
networks with randomized names, but the subnetwork names will remain
static. Because subnetworks are regional resources, you can't have two
subnetworks with the same name tied to the same project and region. This
means that without adding randomness to subnetwork names, only 1 run of
the integration test pipeline can occur at any given time.

Normally a random_string resource is used to impart randomness into
resource names, but the way the Network module performs lookups on the
`var.subnets` and `var.secondary_ranges` input variables, those
variables cannot contain computed values. To remedy this, the test
fixtures now include an input variable named
`var.random_string_for_testing` that accepts a string to be appended on
both the network and subnetwork names. The `test/ci_integration.sh`
script has been modified to look for an environment variable named
`RANDOM_STRING_FOR_TESTING` and pass that to
`var.random_string_for_testing`. If that environment variable has not been
declared then a 5-character string is generated on the fly and used.

The random_string resource has been deleted completely in favor of
`var.random_string_for_testing` so that all resources generated in
an integration test run can use the same random characters (to
make it easier to track down all the resources from a single run
if we ever need to do that in the future).