### PR TITLE
feat: add pre-commit to automatically format and create docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+- repo: git://github.com/antonbabenko/pre-commit-terraform
+  rev: v1.11.0
+  hooks:
+    - id: terraform_fmt
+    - id: terraform_docs
+    - id: terraform_validate_with_variables

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,17 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 - repo: git://github.com/antonbabenko/pre-commit-terraform
   rev: v1.11.0
   hooks:


### PR DESCRIPTION
### Why

I find pre-commit useful in that it won't let me commit if terraform is not properly formatted or docs need to be updated.  