### PR TITLE
Fix bug in gsuite_group module that requires organizationViewer role

### DIFF
--- a/modules/gsuite_group/main.tf
+++ b/modules/gsuite_group/main.tf
@@ -15,13 +15,15 @@
  */
 
 locals {
-  domain = "${var.domain != "" ? var.domain : data.google_organization.org.domain}"
-  email  = "${format("%s@%s", var.name, local.domain)}"
+  domain_list = "${concat(data.google_organization.org.*.domain, list("dummy"))}"
+  domain      = "${var.domain == "" ? element(local.domain_list, 0) : var.domain}"
+  email       = "${format("%s@%s", var.name, local.domain)}"
 }
 
 /*****************************************
   Organization info retrieval
  *****************************************/
 data "google_organization" "org" {
+  count        = "${var.domain == "" ? 1 : 0}"
   organization = "${var.org_id}"
 }


### PR DESCRIPTION
* `roles/organizationViewer` role should not be necessary if domain is specified.
* Error occurs when project factory is scoped to the folder level (i.e. no org-level permissions, only folder-level permissions)

```
data.google_organization.org: Refreshing state...
       Error: Error refreshing state: 1 error(s) occurred:
       * module.project-factory.module.gsuite_group.data.google_organization.org: 1 error(s) occurred:
       * module.project-factory.module.gsuite_group.data.google_organization.org: data.google_organization.org: Error reading Organization Not Found : <org-id-redacted>: googleapi: Error 403: The caller does not have permission, forbidden
```

The fix disables the `data.organization` lookup when the variable `domain` is specified.