### PR TITLE
fix KeyError when billing permission requirements are unsatisfied

### DIFF
--- a/modules/core_project_factory/scripts/preconditions/preconditions.py
+++ b/modules/core_project_factory/scripts/preconditions/preconditions.py
@@ -286,16 +286,13 @@ class BillingAccount:
         request = service.billingAccounts().testIamPermissions(
             resource=resource,
             body=body)
-        try:
-            response = request.execute()
-        except errors.HttpError:
-            response = {"permissions": []}
+        response = request.execute()
 
         req = Requirements(
             "Service account permissions on billing account",
             resource,
             self.REQUIRED_PERMISSIONS,
-            response["permissions"],
+            response.get("permissions", []),
         )
 
         return req.asdict()

--- a/test/integration/shared_vpc_no_subnets/inspec.yml
+++ b/test/integration/shared_vpc_no_subnets/inspec.yml
@@ -16,7 +16,7 @@ name: shared_vpc_no_subnets
 depends:
   - name: inspec-gcp
     git: https://github.com/inspec/inspec-gcp.git
-    version: ~> 0.9.0
+    tag: v0.10.0
 attributes:
   - name: project_id
     required: true


### PR DESCRIPTION
Instead of throwing a KeyError like this:
```
* module.project-factory.module.project-factory.null_resource.preconditions: Error running command '/cft/workdir/test/fixtures/minimal/.terraform/modules/76c2ddba7cd279abe2254470a2c70bac/scripts/prec
onditions.sh \
           --credentials_path '' \
           --billing_account '<redacted>' \
           --org_id '<redacted>' \
           --folder_id '<redacted>' \
           --shared_vpc ''
       ': exit status 1. Output: Traceback (most recent call last):
         File "/cft/workdir/test/fixtures/minimal/.terraform/modules/76c2ddba7cd279abe2254470a2c70bac/scripts/preconditions/preconditions.py", line 455, in <module>
           retcode = main(sys.argv)
         File "/cft/workdir/test/fixtures/minimal/.terraform/modules/76c2ddba7cd279abe2254470a2c70bac/scripts/preconditions/preconditions.py", line 437, in main
           results.append(validator.validate(credentials))
         File "/cft/workdir/test/fixtures/minimal/.terraform/modules/76c2ddba7cd279abe2254470a2c70bac/scripts/preconditions/preconditions.py", line 298, in validate
           response["permissions"],
       KeyError: 'permissions'
```

The precondition script will output a proper error like this:
```
* module.project-factory.module.project-factory.null_resource.preconditions: Error running command '/cft/workdir/test/fixtures/minimal/.terraform/modules/76c2ddba7cd279abe2254470a2c70bac/scripts/prec
onditions.sh \
           --credentials_path '' \
           --billing_account '<redacted>' \
           --org_id '<redacted>' \
           --folder_id '<redacted>' \
           --shared_vpc ''
       ': exit status 1. Output: [
           {
        "type": "Required APIs on service account project",
        "name": "projects/cft-seed",
        "satisfied": [
            "appengine.googleapis.com",
            "iam.googleapis.com",
            "cloudresourcemanager.googleapis.com",
            "admin.googleapis.com",
            "cloudbilling.googleapis.com"
        ],
        "unsatisfied": []
           },
           {
        "type": "Service account permissions on billing account",
        "name": "billingAccounts/<redacted>",
        "satisfied": [],
        "unsatisfied": [
            "billing.resourceAssociations.create"
        ]
           },
           {
        "type": "Service account permissions on parent folder",
        "name": "folders/<redacted>",
        "satisfied": [],
        "unsatisfied": [
            "resourcemanager.projects.create"
        ]
           },
           {
        "type": "Service account permissions on organization",
        "name": "organizations/<redacted>",
        "satisfied": [],
        "unsatisfied": [
            "resourcemanager.organizations.get"
        ]
           }
       ]
```