### PR TITLE
remove permission check for resourcemanager.organization.get

### DIFF
--- a/modules/core_project_factory/scripts/preconditions/preconditions.py
+++ b/modules/core_project_factory/scripts/preconditions/preconditions.py
@@ -71,10 +71,7 @@ class Requirements:
 
 class OrgPermissions:
     # Permissions that the service account must have for any organization
-    ALL_PERMISSIONS = [
-        # Typically granted with `roles/resourcemanager.organizationViewer`
-        "resourcemanager.organizations.get",
-    ]
+    ALL_PERMISSIONS = []
 
     # Permissions required when the service account is attaching a new project
     # to a shared VPC

--- a/modules/core_project_factory/scripts/preconditions/preconditions.py
+++ b/modules/core_project_factory/scripts/preconditions/preconditions.py
@@ -123,7 +123,7 @@ class OrgPermissions:
                 "satisfied": [],
                 "unsatisfied": []
             }
-        
+
         service = discovery.build(
             'cloudresourcemanager', 'v1',
             credentials=credentials

--- a/modules/core_project_factory/scripts/preconditions/preconditions.py
+++ b/modules/core_project_factory/scripts/preconditions/preconditions.py
@@ -112,13 +112,22 @@ class OrgPermissions:
             self.permissions += self.PARENT_PERMISSIONS
 
     def validate(self, credentials):
+        body = {"permissions": self.permissions}
+        resource = "organizations/" + self.org_id
+
+        # no permissions to validate
+        if len(self.permissions) == 0:
+            return {
+                "type": "Service account permissions on organization",
+                "name": resource,
+                "satisfied": [],
+                "unsatisfied": []
+            }
+        
         service = discovery.build(
             'cloudresourcemanager', 'v1',
             credentials=credentials
         )
-
-        body = {"permissions": self.permissions}
-        resource = "organizations/" + self.org_id
 
         request = service.organizations().testIamPermissions(
             resource=resource,

--- a/test/scripts/preconditions/test_preconditions.py
+++ b/test/scripts/preconditions/test_preconditions.py
@@ -107,21 +107,11 @@ class TestRequirements(unittest.TestCase):
 
 
 class TestOrgPermissions(unittest.TestCase):
-    def test_base_permissions(self):
-        org_perms = preconditions.OrgPermissions("1234567890")
-        self.assertEqual(
-            org_perms.permissions,
-            [
-                "resourcemanager.organizations.get",
-            ]
-        )
-
     def test_shared_vpc_permissions(self):
         org_perms = preconditions.OrgPermissions("1234567890", shared_vpc=True)
         self.assertEqual(
             org_perms.permissions,
             [
-                "resourcemanager.organizations.get",
                 "compute.subnetworks.setIamPolicy",
                 "compute.organizations.enableXpnResource",
             ]
@@ -132,7 +122,6 @@ class TestOrgPermissions(unittest.TestCase):
         self.assertEqual(
             org_perms.permissions,
             [
-                "resourcemanager.organizations.get",
                 "resourcemanager.projects.create"
             ]
         )

--- a/test/scripts/preconditions/test_preconditions.py
+++ b/test/scripts/preconditions/test_preconditions.py
@@ -107,6 +107,10 @@ class TestRequirements(unittest.TestCase):
 
 
 class TestOrgPermissions(unittest.TestCase):
+    def test_base_permissions(self):
+        org_perms = preconditions.OrgPermissions("1234567890")
+        self.assertEqual(org_perms.permissions, [])
+
     def test_shared_vpc_permissions(self):
         org_perms = preconditions.OrgPermissions("1234567890", shared_vpc=True)
         self.assertEqual(


### PR DESCRIPTION
This org-level permission is not required in most cases - it is only required for the `gsuite_group` module when "domain" is not specified. Enhancement to add this conditional verification to the `gsuite_group` module will be handled in a subsequent, separate PR.