### PR TITLE
Add Shared VPC example and fix dependencies

### DIFF
--- a/examples/shared_vpc/README.md
+++ b/examples/shared_vpc/README.md
@@ -1,0 +1,27 @@
+# Shared VPC Host Project
+
+This example illustrates how to create a [Shared VPC](https://cloud.google.com/vpc/docs/shared-vpc) host project.
+
+It includes creating the host project and using the [network module](https://github.com/terraform-google-modules/terraform-google-network) to create network.
+
+[^]: (autogen_docs_start)
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| billing\_account | The ID of the billing account to associate this project with | string | - | yes |
+| credentials\_path | Path to a Service Account credentials file with permissions documented in the readme | string | - | yes |
+| host\_project\_name | Name for Shared VPC host project | string | `shared-vpc-host` | no |
+| network\_name | Name for Shared VPC network | string | `shared-network` | no |
+| organization\_id | The organization id for the associated services | string | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| host\_project\_id | The ID of the created project |
+| network\_name | The name of the VPC being created |
+| network\_self\_link | The URI of the VPC being created |
+
+[^]: (autogen_docs_end)

--- a/examples/shared_vpc/main.tf
+++ b/examples/shared_vpc/main.tf
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  credentials_file_path = "${var.credentials_path}"
+  subnet_01             = "${var.network_name}-subnet-01"
+  subnet_02             = "${var.network_name}-subnet-02"
+}
+
+/******************************************
+  Provider configuration
+ *****************************************/
+provider "google" {
+  credentials = "${file(local.credentials_file_path)}"
+  version     = "~> 1.19"
+}
+
+provider "google-beta" {
+  credentials = "${file(local.credentials_file_path)}"
+  version     = "~> 1.19"
+}
+
+/******************************************
+  Host Project Creation
+ *****************************************/
+module "host-project" {
+  source            = "../../"
+  random_project_id = "true"
+  name              = "${var.host_project_name}"
+  org_id            = "${var.organization_id}"
+  billing_account   = "${var.billing_account}"
+  credentials_path  = "${local.credentials_file_path}"
+}
+
+/******************************************
+  Network Creation
+ *****************************************/
+module "vpc" {
+  source  = "terraform-google-modules/network/google"
+  version = "0.6.0"
+
+  project_id   = "${module.host-project.project_id}"
+  network_name = "${var.network_name}"
+
+  delete_default_internet_gateway_routes = "true"
+  shared_vpc_host                        = "true"
+
+  subnets = [
+    {
+      subnet_name   = "${local.subnet_01}"
+      subnet_ip     = "10.10.10.0/24"
+      subnet_region = "us-west1"
+    },
+    {
+      subnet_name           = "${local.subnet_02}"
+      subnet_ip             = "10.10.20.0/24"
+      subnet_region         = "us-west1"
+      subnet_private_access = "true"
+      subnet_flow_logs      = "true"
+    },
+  ]
+
+  secondary_ranges = {
+    "${local.subnet_01}" = []
+    "${local.subnet_02}" = []
+  }
+}

--- a/examples/shared_vpc/outputs.tf
+++ b/examples/shared_vpc/outputs.tf
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "host_project_id" {
+  value       = "${module.host-project.project_id}"
+  description = "The ID of the created project"
+}
+
+output "network_name" {
+  value       = "${module.vpc.network_name}"
+  description = "The name of the VPC being created"
+}
+
+output "network_self_link" {
+  value       = "${module.vpc.network_self_link}"
+  description = "The URI of the VPC being created"
+}

--- a/examples/shared_vpc/variables.tf
+++ b/examples/shared_vpc/variables.tf
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "organization_id" {
+  description = "The organization id for the associated services"
+}
+
+variable "billing_account" {
+  description = "The ID of the billing account to associate this project with"
+}
+
+variable "credentials_path" {
+  description = "Path to a Service Account credentials file with permissions documented in the readme"
+}
+
+variable "host_project_name" {
+  description = "Name for Shared VPC host project"
+  default     = "shared-vpc-host"
+}
+
+variable "network_name" {
+  description = "Name for Shared VPC network"
+  default     = "shared-network"
+}

--- a/modules/core_project_factory/outputs.tf
+++ b/modules/core_project_factory/outputs.tf
@@ -19,7 +19,7 @@ output "project_name" {
 }
 
 output "project_id" {
-  value = "${element(concat(google_project_service.project_services.*.project, list(local.project_id)), 0)}"
+  value = "${element(concat(google_project_service.project_services.*.project, list(google_project.main.project_id)), 0)}"
 }
 
 output "project_number" {

--- a/modules/core_project_factory/outputs.tf
+++ b/modules/core_project_factory/outputs.tf
@@ -19,7 +19,7 @@ output "project_name" {
 }
 
 output "project_id" {
-  value = "${google_project.main.project_id}"
+  value = "${element(concat(google_project_service.project_services.*.project, list(local.project_id)), 0)}"
 }
 
 output "project_number" {


### PR DESCRIPTION
This PR:

- Adds an example of combining the project factory and shared VPC modules to create a host project
- Fixes https://github.com/terraform-google-modules/terraform-google-network/issues/15 by making the project ID output depend on project service activation