### PR TITLE
required versions of providers added to shared_vpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Extending the adopted spec, each change should have a link to its corresponding 
 
 ## [Unreleased]
 
+### Fixed
+
+ - Versions of providers has been fixed for examples/shared_vpc [#198]
+
+
 ## [2.2.0] - 2019-05-03
 
 ### Added

--- a/examples/shared_vpc/main.tf
+++ b/examples/shared_vpc/main.tf
@@ -25,12 +25,12 @@ locals {
  *****************************************/
 provider "google" {
   credentials = "${file(local.credentials_file_path)}"
-  version     = "~> 1.19"
+  version     = "~> 2.1"
 }
 
 provider "google-beta" {
   credentials = "${file(local.credentials_file_path)}"
-  version     = "~> 1.19"
+  version     = "~> 2.1"
 }
 
 /******************************************

--- a/examples/shared_vpc/main.tf
+++ b/examples/shared_vpc/main.tf
@@ -25,12 +25,12 @@ locals {
  *****************************************/
 provider "google" {
   credentials = "${file(local.credentials_file_path)}"
-  version     = "~> 2.1"
+  version     = "~> 2.1.0"
 }
 
 provider "google-beta" {
   credentials = "${file(local.credentials_file_path)}"
-  version     = "~> 2.1"
+  version     = "~> 2.1.0"
 }
 
 /******************************************


### PR DESCRIPTION
Versions for providers has been fixed for examples/shared_vpc