### PR TITLE
Add the cloudservices service account output to the fabric submodule

### DIFF
--- a/modules/fabric-project/README.md
+++ b/modules/fabric-project/README.md
@@ -60,6 +60,7 @@ module "project_myproject" {
 
 | Name | Description |
 |------|-------------|
+| cloudsvc\_service\_account | Cloud services service account (depends on services). |
 | custom\_roles | Ids of the created custom roles. |
 | gce\_service\_account | Default GCE service account (depends on services). |
 | gke\_service\_account | Default GKE service account (depends on services). |

--- a/modules/fabric-project/main.tf
+++ b/modules/fabric-project/main.tf
@@ -18,10 +18,11 @@
 # https://github.com/hashicorp/terraform/issues/3116
 
 locals {
-  all_oslogin_users   = "${concat(var.oslogin_users, var.oslogin_admins)}"
-  num_oslogin_users   = "${length(var.oslogin_users) + length(var.oslogin_admins)}"
-  gce_service_account = "${google_project.project.number}-compute@developer.gserviceaccount.com"
-  gke_service_account = "service-${google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
+  all_oslogin_users        = "${concat(var.oslogin_users, var.oslogin_admins)}"
+  num_oslogin_users        = "${length(var.oslogin_users) + length(var.oslogin_admins)}"
+  cloudsvc_service_account = "${google_project.project.number}@cloudservices.gserviceaccount.com"
+  gce_service_account      = "${google_project.project.number}-compute@developer.gserviceaccount.com"
+  gke_service_account      = "service-${google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
 }
 
 resource "google_project" "project" {

--- a/modules/fabric-project/outputs.tf
+++ b/modules/fabric-project/outputs.tf
@@ -26,6 +26,12 @@ output "number" {
   depends_on  = ["google_project_services.services"]
 }
 
+output "cloudsvc_service_account" {
+  description = "Cloud services service account (depends on services)."
+  value       = "${local.cloudsvc_service_account}"
+  depends_on  = ["google_project_services.services"]
+}
+
 output "gce_service_account" {
   description = "Default GCE service account (depends on services)."
   value       = "${local.gce_service_account}"


### PR DESCRIPTION
This adds a simple computed output to expose the cloudservices service account in the fabric submodule outputs, as a convenience when [setting project service access for GKE to shared VPC subnets](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc#summary_of_roles_granted_on_subnets).