### PR TITLE
Fixes #192 Permissions required by setup-sa.sh not documented

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,51 +104,51 @@ determining that location is as follows:
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| activate\_apis | The list of apis to activate within the project | list | `<list>` | no |
-| apis\_authority | Toggles authoritative management of project services. | string | `"false"` | no |
-| auto\_create\_network | Create the default network | string | `"false"` | no |
-| billing\_account | The ID of the billing account to associate this project with | string | n/a | yes |
-| bucket\_location | The location for a GCS bucket to create (optional) | string | `"US"` | no |
-| bucket\_name | A name for a GCS bucket to create (in the bucket_project project), useful for Terraform state (optional) | string | `""` | no |
-| bucket\_project | A project to create a GCS bucket (bucket_name) in, useful for Terraform state (optional) | string | `""` | no |
-| credentials\_path | Path to a service account credentials file with rights to run the Project Factory. If this file is absent Terraform will fall back to Application Default Credentials. | string | `""` | no |
-| default\_service\_account | Project default service account setting: (delete | depriviledge | keep) | string | `"delete"` | no |
-| disable\_dependent\_services | Whether services that are enabled and which depend on this service should also be disabled when this service is destroyed. | string | `"true"` | no |
-| disable\_services\_on\_destroy | Whether project services will be disabled when the resources are destroyed | string | `"true"` | no |
-| domain | The domain name (optional). | string | `""` | no |
-| folder\_id | The ID of a folder to host this project | string | `""` | no |
-| group\_name | A group to control the project by being assigned group_role (defaults to project editor) | string | `""` | no |
-| group\_role | The role to give the controlling group (group_name) over the project (defaults to project editor) | string | `"roles/editor"` | no |
-| labels | Map of labels for project | map | `<map>` | no |
-| lien | Add a lien on the project to prevent accidental deletion | string | `"false"` | no |
-| name | The name for the project | string | n/a | yes |
-| org\_id | The organization ID. | string | n/a | yes |
-| project\_id | If provided, the project uses the given project ID. Mutually exclusive with random_project_id being true. | string | `""` | no |
-| random\_project\_id | Enables project random id generation. Mutually exclusive with project_id being non-empty. | string | `"false"` | no |
-| sa\_role | A role to give the default Service Account for the project (defaults to none) | string | `""` | no |
-| shared\_vpc | The ID of the host project which hosts the shared VPC | string | `""` | no |
-| shared\_vpc\_subnets | List of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id) | list | `<list>` | no |
-| usage\_bucket\_name | Name of a GCS bucket to store GCE usage reports in (optional) | string | `""` | no |
-| usage\_bucket\_prefix | Prefix in the GCS bucket to store GCE usage reports in (optional) | string | `""` | no |
+| Name                           | Description                                                                                                                                                            |     Type     |     Default      | Required |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----------: | :--------------: | :------: |
+| activate\_apis                 | The list of apis to activate within the project                                                                                                                        |     list     |     `<list>`     |    no    |
+| apis\_authority                | Toggles authoritative management of project services.                                                                                                                  |    string    |    `"false"`     |    no    |
+| auto\_create\_network          | Create the default network                                                                                                                                             |    string    |    `"false"`     |    no    |
+| billing\_account               | The ID of the billing account to associate this project with                                                                                                           |    string    |       n/a        |   yes    |
+| bucket\_location               | The location for a GCS bucket to create (optional)                                                                                                                     |    string    |      `"US"`      |    no    |
+| bucket\_name                   | A name for a GCS bucket to create (in the bucket_project project), useful for Terraform state (optional)                                                               |    string    |       `""`       |    no    |
+| bucket\_project                | A project to create a GCS bucket (bucket_name) in, useful for Terraform state (optional)                                                                               |    string    |       `""`       |    no    |
+| credentials\_path              | Path to a service account credentials file with rights to run the Project Factory. If this file is absent Terraform will fall back to Application Default Credentials. |    string    |       `""`       |    no    |
+| default\_service\_account      | Project default service account setting: (delete                                                                                                                       | depriviledge |      keep)       |  string  | `"delete"` | no |
+| disable\_dependent\_services   | Whether services that are enabled and which depend on this service should also be disabled when this service is destroyed.                                             |    string    |     `"true"`     |    no    |
+| disable\_services\_on\_destroy | Whether project services will be disabled when the resources are destroyed                                                                                             |    string    |     `"true"`     |    no    |
+| domain                         | The domain name (optional).                                                                                                                                            |    string    |       `""`       |    no    |
+| folder\_id                     | The ID of a folder to host this project                                                                                                                                |    string    |       `""`       |    no    |
+| group\_name                    | A group to control the project by being assigned group_role (defaults to project editor)                                                                               |    string    |       `""`       |    no    |
+| group\_role                    | The role to give the controlling group (group_name) over the project (defaults to project editor)                                                                      |    string    | `"roles/editor"` |    no    |
+| labels                         | Map of labels for project                                                                                                                                              |     map      |     `<map>`      |    no    |
+| lien                           | Add a lien on the project to prevent accidental deletion                                                                                                               |    string    |    `"false"`     |    no    |
+| name                           | The name for the project                                                                                                                                               |    string    |       n/a        |   yes    |
+| org\_id                        | The organization ID.                                                                                                                                                   |    string    |       n/a        |   yes    |
+| project\_id                    | If provided, the project uses the given project ID. Mutually exclusive with random_project_id being true.                                                              |    string    |       `""`       |    no    |
+| random\_project\_id            | Enables project random id generation. Mutually exclusive with project_id being non-empty.                                                                              |    string    |    `"false"`     |    no    |
+| sa\_role                       | A role to give the default Service Account for the project (defaults to none)                                                                                          |    string    |       `""`       |    no    |
+| shared\_vpc                    | The ID of the host project which hosts the shared VPC                                                                                                                  |    string    |       `""`       |    no    |
+| shared\_vpc\_subnets           | List of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id)                                                           |     list     |     `<list>`     |    no    |
+| usage\_bucket\_name            | Name of a GCS bucket to store GCE usage reports in (optional)                                                                                                          |    string    |       `""`       |    no    |
+| usage\_bucket\_prefix          | Prefix in the GCS bucket to store GCE usage reports in (optional)                                                                                                      |    string    |       `""`       |    no    |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| domain | The organization's domain |
-| group\_email | The email of the GSuite group with group_name |
-| project\_bucket\_self\_link | Project's bucket selfLink |
-| project\_bucket\_url | Project's bucket url |
-| project\_id |  |
-| project\_name |  |
-| project\_number |  |
-| service\_account\_display\_name | The display name of the default service account |
-| service\_account\_email | The email of the default service account |
-| service\_account\_id | The id of the default service account |
-| service\_account\_name | The fully-qualified name of the default service account |
-| service\_account\_unique\_id | The unique id of the default service account |
+| Name                            | Description                                             |
+| ------------------------------- | ------------------------------------------------------- |
+| domain                          | The organization's domain                               |
+| group\_email                    | The email of the GSuite group with group_name           |
+| project\_bucket\_self\_link     | Project's bucket selfLink                               |
+| project\_bucket\_url            | Project's bucket url                                    |
+| project\_id                     |                                                         |
+| project\_name                   |                                                         |
+| project\_number                 |                                                         |
+| service\_account\_display\_name | The display name of the default service account         |
+| service\_account\_email         | The email of the default service account                |
+| service\_account\_id            | The id of the default service account                   |
+| service\_account\_name          | The fully-qualified name of the default service account |
+| service\_account\_unique\_id    | The unique id of the default service account            |
 
 [^]: (autogen_docs_end)
 
@@ -188,8 +188,25 @@ Account in the Seed Project, grant the necessary roles to the Seed Service
 Account, and enable the necessary API's in the Seed Project.  Run it as follows:
 
 ```sh
-./helpers/setup-sa.sh <ORGANIZATION_ID> <SEED_PROJECT_NAME>
+./helpers/setup-sa.sh <ORGANIZATION_ID> <SEED_PROJECT_NAME> <BILLING_ACCOUNT>
 ```
+
+In order to execute this script you must have an account with following list of
+bare-minimum permissions:
+
+- `resourcemanager.organizations.list`
+- `resourcemanager.organizations.setIamPolicy`
+- `iam.serviceAccounts.create`
+- `iam.serviceAccountKeys.create`
+- `resourcemanager.projects.setIamPolicy`
+- `serviceusage.services.enable` on the project
+- `servicemanagement.services.bind` on following services:
+  - cloudbilling.googleapis.com
+  - iam.googleapis.com
+  - admin.googleapis.com
+  - appengine.googleapis.com
+- `billing.accounts.getIamPolicy` on a billing account.
+- `billing.accounts.setIamPolicy` on a billing account.
 
 #### Specifying credentials
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Account, and enable the necessary API's in the Seed Project.  Run it as follows:
 ```
 
 In order to execute this script, you must have an account with the following list of
-bare-minimum permissions:
+permissions:
 
 - `resourcemanager.organizations.list`
 - `resourcemanager.organizations.setIamPolicy`

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Account in the Seed Project, grant the necessary roles to the Seed Service
 Account, and enable the necessary API's in the Seed Project.  Run it as follows:
 
 ```sh
-./helpers/setup-sa.sh <ORGANIZATION_ID> <SEED_PROJECT_NAME> <BILLING_ACCOUNT>
+./helpers/setup-sa.sh <ORGANIZATION_ID> <SEED_PROJECT_NAME> [BILLING_ACCOUNT]
 ```
 
 In order to execute this script you must have an account with following list of

--- a/README.md
+++ b/README.md
@@ -195,12 +195,15 @@ In order to execute this script, you must have an account with the following lis
 permissions:
 
 - `resourcemanager.organizations.list`
-- `resourcemanager.organizations.setIamPolicy`
+- `resourcemanager.projects.list`
+- `billing.accounts.list`
 - `iam.serviceAccounts.create`
 - `iam.serviceAccountKeys.create`
+- `resourcemanager.organizations.setIamPolicy`
 - `resourcemanager.projects.setIamPolicy`
 - `serviceusage.services.enable` on the project
 - `servicemanagement.services.bind` on following services:
+  - cloudresourcemanager.googleapis.com
   - cloudbilling.googleapis.com
   - iam.googleapis.com
   - admin.googleapis.com

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Account, and enable the necessary API's in the Seed Project.  Run it as follows:
 ./helpers/setup-sa.sh <ORGANIZATION_ID> <SEED_PROJECT_NAME> [BILLING_ACCOUNT]
 ```
 
-In order to execute this script you must have an account with following list of
+In order to execute this script, you must have an account with the following list of
 bare-minimum permissions:
 
 - `resourcemanager.organizations.list`

--- a/README.md
+++ b/README.md
@@ -104,51 +104,51 @@ determining that location is as follows:
 
 ## Inputs
 
-| Name                           | Description                                                                                                                                                            |     Type     |     Default      | Required |
-| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----------: | :--------------: | :------: |
-| activate\_apis                 | The list of apis to activate within the project                                                                                                                        |     list     |     `<list>`     |    no    |
-| apis\_authority                | Toggles authoritative management of project services.                                                                                                                  |    string    |    `"false"`     |    no    |
-| auto\_create\_network          | Create the default network                                                                                                                                             |    string    |    `"false"`     |    no    |
-| billing\_account               | The ID of the billing account to associate this project with                                                                                                           |    string    |       n/a        |   yes    |
-| bucket\_location               | The location for a GCS bucket to create (optional)                                                                                                                     |    string    |      `"US"`      |    no    |
-| bucket\_name                   | A name for a GCS bucket to create (in the bucket_project project), useful for Terraform state (optional)                                                               |    string    |       `""`       |    no    |
-| bucket\_project                | A project to create a GCS bucket (bucket_name) in, useful for Terraform state (optional)                                                                               |    string    |       `""`       |    no    |
-| credentials\_path              | Path to a service account credentials file with rights to run the Project Factory. If this file is absent Terraform will fall back to Application Default Credentials. |    string    |       `""`       |    no    |
-| default\_service\_account      | Project default service account setting: (delete                                                                                                                       | depriviledge |      keep)       |  string  | `"delete"` | no |
-| disable\_dependent\_services   | Whether services that are enabled and which depend on this service should also be disabled when this service is destroyed.                                             |    string    |     `"true"`     |    no    |
-| disable\_services\_on\_destroy | Whether project services will be disabled when the resources are destroyed                                                                                             |    string    |     `"true"`     |    no    |
-| domain                         | The domain name (optional).                                                                                                                                            |    string    |       `""`       |    no    |
-| folder\_id                     | The ID of a folder to host this project                                                                                                                                |    string    |       `""`       |    no    |
-| group\_name                    | A group to control the project by being assigned group_role (defaults to project editor)                                                                               |    string    |       `""`       |    no    |
-| group\_role                    | The role to give the controlling group (group_name) over the project (defaults to project editor)                                                                      |    string    | `"roles/editor"` |    no    |
-| labels                         | Map of labels for project                                                                                                                                              |     map      |     `<map>`      |    no    |
-| lien                           | Add a lien on the project to prevent accidental deletion                                                                                                               |    string    |    `"false"`     |    no    |
-| name                           | The name for the project                                                                                                                                               |    string    |       n/a        |   yes    |
-| org\_id                        | The organization ID.                                                                                                                                                   |    string    |       n/a        |   yes    |
-| project\_id                    | If provided, the project uses the given project ID. Mutually exclusive with random_project_id being true.                                                              |    string    |       `""`       |    no    |
-| random\_project\_id            | Enables project random id generation. Mutually exclusive with project_id being non-empty.                                                                              |    string    |    `"false"`     |    no    |
-| sa\_role                       | A role to give the default Service Account for the project (defaults to none)                                                                                          |    string    |       `""`       |    no    |
-| shared\_vpc                    | The ID of the host project which hosts the shared VPC                                                                                                                  |    string    |       `""`       |    no    |
-| shared\_vpc\_subnets           | List of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id)                                                           |     list     |     `<list>`     |    no    |
-| usage\_bucket\_name            | Name of a GCS bucket to store GCE usage reports in (optional)                                                                                                          |    string    |       `""`       |    no    |
-| usage\_bucket\_prefix          | Prefix in the GCS bucket to store GCE usage reports in (optional)                                                                                                      |    string    |       `""`       |    no    |
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| activate\_apis | The list of apis to activate within the project | list | `<list>` | no |
+| apis\_authority | Toggles authoritative management of project services. | string | `"false"` | no |
+| auto\_create\_network | Create the default network | string | `"false"` | no |
+| billing\_account | The ID of the billing account to associate this project with | string | n/a | yes |
+| bucket\_location | The location for a GCS bucket to create (optional) | string | `"US"` | no |
+| bucket\_name | A name for a GCS bucket to create (in the bucket_project project), useful for Terraform state (optional) | string | `""` | no |
+| bucket\_project | A project to create a GCS bucket (bucket_name) in, useful for Terraform state (optional) | string | `""` | no |
+| credentials\_path | Path to a service account credentials file with rights to run the Project Factory. If this file is absent Terraform will fall back to Application Default Credentials. | string | `""` | no |
+| default\_service\_account | Project default service account setting: (delete | depriviledge | keep) | string | `"delete"` | no |
+| disable\_dependent\_services | Whether services that are enabled and which depend on this service should also be disabled when this service is destroyed. | string | `"true"` | no |
+| disable\_services\_on\_destroy | Whether project services will be disabled when the resources are destroyed | string | `"true"` | no |
+| domain | The domain name (optional). | string | `""` | no |
+| folder\_id | The ID of a folder to host this project | string | `""` | no |
+| group\_name | A group to control the project by being assigned group_role (defaults to project editor) | string | `""` | no |
+| group\_role | The role to give the controlling group (group_name) over the project (defaults to project editor) | string | `"roles/editor"` | no |
+| labels | Map of labels for project | map | `<map>` | no |
+| lien | Add a lien on the project to prevent accidental deletion | string | `"false"` | no |
+| name | The name for the project | string | n/a | yes |
+| org\_id | The organization ID. | string | n/a | yes |
+| project\_id | If provided, the project uses the given project ID. Mutually exclusive with random_project_id being true. | string | `""` | no |
+| random\_project\_id | Enables project random id generation. Mutually exclusive with project_id being non-empty. | string | `"false"` | no |
+| sa\_role | A role to give the default Service Account for the project (defaults to none) | string | `""` | no |
+| shared\_vpc | The ID of the host project which hosts the shared VPC | string | `""` | no |
+| shared\_vpc\_subnets | List of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id) | list | `<list>` | no |
+| usage\_bucket\_name | Name of a GCS bucket to store GCE usage reports in (optional) | string | `""` | no |
+| usage\_bucket\_prefix | Prefix in the GCS bucket to store GCE usage reports in (optional) | string | `""` | no |
 
 ## Outputs
 
-| Name                            | Description                                             |
-| ------------------------------- | ------------------------------------------------------- |
-| domain                          | The organization's domain                               |
-| group\_email                    | The email of the GSuite group with group_name           |
-| project\_bucket\_self\_link     | Project's bucket selfLink                               |
-| project\_bucket\_url            | Project's bucket url                                    |
-| project\_id                     |                                                         |
-| project\_name                   |                                                         |
-| project\_number                 |                                                         |
-| service\_account\_display\_name | The display name of the default service account         |
-| service\_account\_email         | The email of the default service account                |
-| service\_account\_id            | The id of the default service account                   |
-| service\_account\_name          | The fully-qualified name of the default service account |
-| service\_account\_unique\_id    | The unique id of the default service account            |
+| Name | Description |
+|------|-------------|
+| domain | The organization's domain |
+| group\_email | The email of the GSuite group with group_name |
+| project\_bucket\_self\_link | Project's bucket selfLink |
+| project\_bucket\_url | Project's bucket url |
+| project\_id |  |
+| project\_name |  |
+| project\_number |  |
+| service\_account\_display\_name | The display name of the default service account |
+| service\_account\_email | The email of the default service account |
+| service\_account\_id | The id of the default service account |
+| service\_account\_name | The fully-qualified name of the default service account |
+| service\_account\_unique\_id | The unique id of the default service account |
 
 [^]: (autogen_docs_end)
 

--- a/helpers/setup-sa.sh
+++ b/helpers/setup-sa.sh
@@ -72,7 +72,7 @@ SA_ID="${SA_NAME}@${SEED_PROJECT}.iam.gserviceaccount.com"
 STAGING_DIR="${PWD}"
 KEY_FILE="${STAGING_DIR}/credentials.json"
 
- echo "Creating Seed Service Account..."
+echo "Creating Seed Service Account..."
 gcloud iam service-accounts \
     --project "${SEED_PROJECT}" create ${SA_NAME} \
     --display-name ${SA_NAME}


### PR DESCRIPTION
#192 
- Added minimum permissions required to run setup.sh into README.MD
- Auto-formatted README.MD
- Added billing account to the list of arguments for setup.sh into README.MD