### PR TITLE
Add `project_services_authority` to `project_id`

### DIFF
--- a/modules/core_project_factory/outputs.tf
+++ b/modules/core_project_factory/outputs.tf
@@ -19,7 +19,7 @@ output "project_name" {
 }
 
 output "project_id" {
-  value = "${element(concat(google_project_service.project_services.*.project, list(google_project.main.project_id)), 0)}"
+  value = "${element(concat(google_project_service.project_services.*.project, google_project_services.project_services_authority.*.project, list(google_project.main.project_id)), 0)}"
 }
 
 output "project_number" {

--- a/modules/gsuite_enabled/variables.tf
+++ b/modules/gsuite_enabled/variables.tf
@@ -87,7 +87,7 @@ variable "activate_apis" {
   type        = "list"
   default     = ["compute.googleapis.com"]
 }
-   
+
 variable "apis_authority" {
   description = "Toggles authoritative management of project services."
   default     = "false"


### PR DESCRIPTION
This commit ensures that `project_id` blocks on the authoritative project services if enabled.