### PR TITLE
fixes bug introduced by tf12 in fabric-project. Bool to number conversion

### DIFF
--- a/modules/fabric-project/main.tf
+++ b/modules/fabric-project/main.tf
@@ -66,7 +66,7 @@ resource "google_project_iam_member" "viewers" {
 }
 
 resource "google_compute_project_metadata_item" "oslogin_meta" {
-  count   = var.oslogin
+  count   = var.oslogin ? 1 : 0
   project = google_project.project.project_id
   key     = "enable-oslogin"
   value   = "TRUE"


### PR DESCRIPTION
In Terraform 12 booleans are not converted to number automatically. This pull request fixes it.