### PR TITLE
Deprecate 'parent_type' and 'parent_id' input variables 

### DIFF
--- a/modules/fabric-project/README.md
+++ b/modules/fabric-project/README.md
@@ -18,8 +18,7 @@ Basic usage of this module is as follows:
 ```hcl
 module "project_myproject" {
   source                    = "terraform-google-modules/project-factory/google//modules/fabric-project"
-  parent_id                 = "1234567890"
-  parent_type               = "folder"
+  parent                    = "folders/1234567890"
   billing_account           = "ABCD-1234-ABCD-1234"
   prefix                    = "staging"
   name                      = "myproject"
@@ -50,8 +49,7 @@ module "project_myproject" {
 | oslogin\_admins | List of IAM-format members that will get OS Login admin role. | list | `<list>` | no |
 | oslogin\_users | List of IAM-format members that will get OS Login user role. | list | `<list>` | no |
 | owners | Optional list of IAM-format members to set as project owners. | list | `<list>` | no |
-| parent\_id | Id of the resource under which the folder will be placed. | string | n/a | yes |
-| parent\_type | Type of the parent resource, defaults to organization. | string | `"organization"` | no |
+| parent | The resource name of the parent Folder or Organization. Must be of the form folders/folder_id or organizations/org_id | string | n/a | yes |
 | prefix | Prefix used to generate project id and name | string | n/a | yes |
 | viewers | Optional list of IAM-format members to set as project viewers. | list | `<list>` | no |
 

--- a/modules/fabric-project/main.tf
+++ b/modules/fabric-project/main.tf
@@ -23,11 +23,13 @@ locals {
   num_oslogin_users        = length(var.oslogin_users) + length(var.oslogin_admins)
   gce_service_account      = "${google_project.project.number}-compute@developer.gserviceaccount.com"
   gke_service_account      = "service-${google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
+  parent_type              = split("/", var.parent)[0]
+  parent_id                = split("/", var.parent)[1]
 }
 
 resource "google_project" "project" {
-  org_id              = var.parent_type == "organization" ? var.parent_id : ""
-  folder_id           = var.parent_type == "folder" ? var.parent_id : ""
+  org_id              = local.parent_type == "organizations" ? local.parent_id : ""
+  folder_id           = local.parent_type == "folders" ? local.parent_id : ""
   project_id          = "${var.prefix}-${var.name}"
   name                = "${var.prefix}-${var.name}"
   billing_account     = var.billing_account

--- a/modules/fabric-project/variables.tf
+++ b/modules/fabric-project/variables.tf
@@ -14,13 +14,8 @@
  * limitations under the License.
  */
 
-variable "parent_id" {
-  description = "Id of the resource under which the folder will be placed."
-}
-
-variable "parent_type" {
-  description = "Type of the parent resource, defaults to organization."
-  default     = "organization"
+variable "parent" {
+  description = "The resource name of the parent Folder or Organization. Must be of the form folders/folder_id or organizations/org_id"
 }
 
 variable "prefix" {


### PR DESCRIPTION
In order to make it easy to use factory-project submodule in combination with https://github.com/terraform-google-modules/terraform-google-folders