### PR TITLE
allow creation of project_bucket within the project we are creating.

### DIFF
--- a/modules/core_project_factory/main.tf
+++ b/modules/core_project_factory/main.tf
@@ -407,7 +407,7 @@ resource "google_storage_bucket" "project_bucket" {
   count = local.create_bucket ? 1 : 0
 
   name     = local.project_bucket_name
-  project  = var.bucket_project
+  project  = var.bucket_project == local.base_project_id ? google_project.main.project_id : var.bucket_project
   location = var.bucket_location
 }
 


### PR DESCRIPTION
previously it wasn't possible to create the project bucket within the project as the project wouldn't exist or wouldn't have the expected random suffix.  This will detect the intent to create the bucket in the project we are creating and use the project's id.