### PR TITLE
Update project-factory version referenced in repository README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ There are multiple examples included in the [examples](./examples/) folder but s
 ```hcl
 module "project-factory" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 2.0"
+  version = "~> 3.0"
 
   name                = "pf-test-1"
   random_project_id   = "true"


### PR DESCRIPTION
The version of project-factory referenced in the repository README is not up to date. Using it in practice with Terraform 0.12 causes errors:

```
Downloading modules/core_project_factory for project.project-factory...

Error: Module not found

The module address "modules/gsuite_group" could not be resolved.

If you intended this as a path relative to the current module, use
"./modules/gsuite_group" instead. The "./" prefix indicates that the address
is a relative filesystem path.


Error: Module not found

The module address "modules/core_project_factory" could not be resolved.

If you intended this as a path relative to the current module, use
"./modules/core_project_factory" instead. The "./" prefix indicates that the
address is a relative filesystem path.
```