### PR TITLE
Use project_services module and convert to for_each

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ determining that location is as follows:
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | activate\_apis | The list of apis to activate within the project | list(string) | `<list>` | no |
-| apis\_authority | Toggles authoritative management of project services. | bool | `"false"` | no |
 | auto\_create\_network | Create the default network | bool | `"false"` | no |
 | billing\_account | The ID of the billing account to associate this project with | string | n/a | yes |
 | bucket\_location | The location for a GCS bucket to create (optional) | string | `"US"` | no |

--- a/docs/upgrading_to_project_factory_v4.0.md
+++ b/docs/upgrading_to_project_factory_v4.0.md
@@ -1,0 +1,208 @@
+# Upgrading to Project Factory v4.0
+
+The v4.0 release of Project Factory is a backwards incompatible release and
+features minor changes, specifically with how Google Project Services (APIs)
+are managed. A state migration script is provided to update your existing states
+to minimize or eliminate resource re-creations.
+
+Note that upgrading requires you to have Python 3.7 installed.
+
+## Migration Instructions
+
+This migration was performed with the following example configuration.
+
+```hcl
+/// @file main.tf
+
+provider "google" {
+  credentials = "${file(var.credentials_path)}"
+}
+
+module "my-project" {
+  source            = "terraform-google-modules/project-factory/google"
+  version           = "v3.0.0"
+  random_project_id = "true"
+  name              = "pf-project-services-migrate"
+  org_id            = "${var.org_id}"
+  billing_account   = "${var.billing_account}"
+  credentials_path  = "${var.credentials_path}"
+  activate_apis = [
+    "compute.googleapis.com",
+    "iamcredentials.googleapis.com",
+  ]
+}
+```
+
+### Update the project-factory source
+
+Update the project-factory module source to the Project Factory v4.0.0 release.
+
+```diff
+diff --git i/main.tf w/main.tf
+index d876954..ebb3b1e 100755
+--- i/main.tf
++++ w/main.tf
+@@ -5,7 +5,7 @@ provider "google" {
+
+ module "my-project" {
+   source            = "terraform-google-modules/project-factory/google"
+-  version           = "v3.0.0"
++  version           = "v4.0.0"
+   random_project_id = "true"
+   name              = "pf-project-services-migrate"
+   org_id            = "${var.org_id}"
+```
+
+### Download the state migration script
+
+ ```
+curl -O https://raw.githubusercontent.com/terraform-google-modules/terraform-google-project-factory/v4.0.0/helpers/migrate4.py
+chmod +x migrate4.py
+```
+
+### Reinitialize Terraform
+
+```
+terraform init -upgrade
+```
+
+### Locally download your Terraform state
+
+This step is only required if you are using [remote state](https://www.terraform.io/docs/state/remote.html).
+
+```
+terraform state pull >> terraform.tfstate
+```
+
+You should then disable remote state temporarily:
+
+```hcl
+terraform {
+#  backend "gcs" {
+#    bucket  = "my-bucket-name"
+#    prefix  = "terraform/state/projects"
+#  }
+}
+```
+
+After commenting out your remote state configuration, you must re-initialize Terraform.
+
+```
+terraform init
+```
+
+### Migrate the Terraform state to match the new Project Factory module structure
+
+```
+./migrate4.py terraform.tfstate terraform.tfstate.new
+```
+
+Expected output:
+```txt
+cp terraform.tfstate terraform.tfstate.new
+---- Migrating the following project-factory modules:
+-- module.my-project.module.project-factory
+Removed module.my-project.module.project-factory.google_project_service.project_services[0]
+Successfully removed 1 resource instance(s).
+module.my-project.module.project-factory.module.project_services.google_project_service.project_services["storage-api.googleapis.com"]: Importing from ID "pf-project-services-migrate/compute.googleapis.com"...
+module.my-project.module.project-factory.module.project_services.google_project_service.project_services["storage-api.googleapis.com"]: Import prepared!
+  Prepared google_project_service for import
+module.my-project.module.project-factory.module.project_services.google_project_service.project_services["storage-api.googleapis.com"]: Refreshing state... [id=pf-project-services-migrate/compute.googleapis.com]
+
+Import successful!
+
+The resources that were imported are shown above. These resources are now in
+your Terraform state and will henceforth be managed by Terraform.
+State migration complete, verify migration with `terraform plan -state 'terraform.tfstate.new'`
+```
+
+### Check that terraform plans for expected changes
+
+```
+terraform plan -state terraform.tfstate.new
+```
+
+The project services refactor will show this for each service:
+
+```
+# module.my-project.module.project-factory.module.project_services.google_project_service.project_services["compute.googleapis.com"] will be updated in-place
+~ resource "google_project_service" "project_services" {
+    + disable_dependent_services = true
+    + disable_on_destroy         = true
+      id                         = "pf-project-services-migrate/compute.googleapis.com"
+      project                    = "pf-project-services-migrate"
+      service                    = "compute.googleapis.com"
+
+      timeouts {}
+  }
+```
+
+### Back up the old Terraform state and switch to the new Terraform state
+
+If the Terraform plan suggests no changes, replace the old state file with the new state file.
+
+```
+mv terraform.tfstate terraform.tfstate.pre-migrate
+mv terraform.tfstate.new terraform.tfstate
+```
+
+### Run Terraform to reconcile any differences
+
+```
+terraform apply
+```
+
+### Re-enable remote state
+
+You should then re-enable remote state:
+
+```hcl
+terraform {
+  backend "gcs" {
+    bucket  = "my-bucket-name"
+    prefix  = "terraform/state/projects"
+  }
+}
+```
+
+After restoring remote state, you need to re-initialize Terraform and push your local state to the remote:
+
+```
+terraform init -force-copy
+```
+
+### Clean up
+
+Once you are done with the migration, you can safely remove `migrate.py`.
+
+```
+rm migrate4.py
+```
+
+If you are using remote state, you can also remove the local state copies.
+
+```
+rm -rf terraform.tfstate*
+```
+
+## Troubleshooting
+
+### The migration script fails to run
+
+If you get an error like this when running the migration script, it means you need upgrade
+your Python version to 3.7.
+
+```
+Traceback (most recent call last):
+  File "./migrate.py", line 372, in <module>
+    main(sys.argv)
+  File "./migrate.py", line 353, in main
+    migrate(args.newstate, dryrun=args.dryrun)
+  File "./migrate.py", line 314, in migrate
+    for path in read_state(statefile)
+  File "./migrate.py", line 282, in read_state
+    encoding='utf-8')
+  File "/usr/local/Cellar/python3/3.6.3/Frameworks/Python.framework/Versions/3.6/lib/python3.6/subprocess.py", line 403, in run
+    with Popen(*popenargs, **kwargs) as process:
+TypeError: __init__() got an unexpected keyword argument 'capture_output'
+```

--- a/helpers/migrate4.py
+++ b/helpers/migrate4.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import copy
+import subprocess
+import sys
+import shutil
+import re
+
+MIGRATIONS = [
+    {
+        "resource_type": "google_project_service",
+        "name": "project_services",
+        "module": ".module.project_services",
+    },
+]
+
+
+class ProjectServicesMigration:
+    """
+    Migrate the project services resources from a project factory to match the
+    new module structure created by the project services deprecation and
+    breakout into its own module.
+    """
+
+    def __init__(self, project_factory, statefile):
+        self.project_factory = project_factory
+        self.statefile = statefile
+
+    def moves(self):
+        """
+        Generate the set of old/new resource pairs that will be migrated
+        to the `project_services` module.
+        """
+        resources = self.targets()
+        moves = []
+        for (old, migration) in resources:
+            new = copy.deepcopy(old)
+            new.module += migration["module"]
+
+            # Update the copied resource with the "rename" value if it is set
+            if "rename" in migration:
+                new.name = migration["rename"]
+            else:
+                # Write over with base name to remove "[0]" suffix
+                new.name = migration["name"]
+
+            # Update the new name with the for_each suffix
+            service_name = read_resource_value(old.path(), "service", self.statefile)
+            if service_name is None:
+                raise ValueError(
+                    "Could not find project service ID for resource {!r}".format(old.path()))
+
+            new.name = '{}["{}"]'.format(new.name, service_name)
+
+            # Create an ID string for importing the resource
+            project_id = read_resource_value(old.path(), "project", self.statefile)
+            if project_id is None:
+                raise ValueError(
+                    "Could not find project ID for resource {!r}".format(old.path()))
+
+            import_address = "{}/{}".format(project_id, service_name)
+
+            pair = (old.path(), new.path(), import_address)
+            moves.append(pair)
+
+        return moves
+
+    def targets(self):
+        """
+        A list of resources that will be moved to the `project_services`
+        module.
+        """
+        to_move = []
+
+        for migration in MIGRATIONS:
+            resource_type = migration["resource_type"]
+            resource_name = migration["name"]
+            matching_resources = self.project_factory.get_resources(
+                resource_type,
+                resource_name)
+            to_move += [(r, migration) for r in matching_resources]
+
+        return to_move
+
+
+class TerraformModule:
+    """
+    A Terraform module with associated resources.
+    """
+
+    def __init__(self, name, resources):
+        """
+        Create a new module and associate it with a list of resources.
+        """
+        self.name = name
+        self.resources = resources
+
+    def get_resources(self, resource_type=None, resource_name=None):
+        """
+        Return a list of resources matching the given resource type and name.
+        """
+
+        name_pattern = re.compile(r'%s(\[\d+\])?' % resource_name)
+
+        ret = []
+        for resource in self.resources:
+            matches_type = (resource_type is None or
+                            resource_type == resource.resource_type)
+
+            matches_name = (resource_name is None or
+                            name_pattern.match(resource.name))
+
+            if matches_type and matches_name:
+                ret.append(resource)
+
+        return ret
+
+    def has_resource(self, resource_type=None, resource_name=None):
+        """
+        Does this module contain a resource with the matching type and name?
+        """
+        for resource in self.resources:
+            matches_type = (resource_type is None or
+                            resource_type == resource.resource_type)
+
+            matches_name = (resource_name is None or
+                            resource_name == resource.name)
+
+            if matches_type and matches_name:
+                return True
+
+        return False
+
+    def __repr__(self):
+        return "{}({!r}, {!r})".format(
+            self.__class__.__name__,
+            self.name,
+            [repr(resource) for resource in self.resources])
+
+
+class TerraformResource:
+    """
+    A Terraform resource, defined by the the identifier of that resource.
+
+    >>> path = 'module.project-factory.google_project.project'
+    >>> resource = TerraformResource.from_path(path)
+    >>> assert resource.module == 'module.project-factory'
+    >>> assert resource.resource_type == 'google_project'
+    >>> assert resource.name == 'project'
+    """
+
+    @classmethod
+    def from_path(cls, path):
+        """
+        Generate a new Terraform resource, based on the fully qualified
+        Terraform resource path.
+        """
+        if re.match(r'\A[\w.\[\]-]+\Z', path) is None:
+            raise ValueError(
+                "Invalid Terraform resource path {!r}".format(path))
+
+        parts = path.split(".")
+        name = parts.pop()
+        resource_type = parts.pop()
+        module = ".".join(parts)
+        return cls(module, resource_type, name)
+
+    def __init__(self, module, resource_type, name):
+        """
+        Create a new TerraformResource from a pre-parsed path.
+        """
+        self.module = module
+        self.resource_type = resource_type
+        self.name = name
+
+    def path(self):
+        """
+        Return the fully qualified resource path.
+        """
+        parts = [self.module, self.resource_type, self.name]
+        if parts[0] == '':
+            del parts[0]
+        return ".".join(parts)
+
+    def __repr__(self):
+        return "{}({!r}, {!r}, {!r})".format(
+            self.__class__.__name__,
+            self.module,
+            self.resource_type,
+            self.name)
+
+
+def group_by_module(resources):
+    """
+    Group a set of resources according to their containing module.
+    """
+
+    groups = {}
+    for resource in resources:
+        if resource.module in groups:
+            groups[resource.module].append(resource)
+        else:
+            groups[resource.module] = [resource]
+
+    return [
+        TerraformModule(name, contained)
+        for name, contained in groups.items()
+    ]
+
+
+def read_state(statefile):
+    """
+    Read the terraform state at the given path.
+    """
+    argv = ["terraform", "state", "list", "-state", statefile]
+    result = subprocess.run(argv,
+                            capture_output=True,
+                            check=True,
+                            encoding='utf-8')
+    elements = result.stdout.split("\n")
+    elements.pop()
+    return elements
+
+
+def read_resource_value(resource, field, statefile):
+    """
+    Read a specific value from a resource from the terraform state at the
+    given path.
+    """
+    argv = ["terraform", "state", "show", "-no-color", "-state", statefile, resource]
+    result = subprocess.run(argv,
+                            capture_output=True,
+                            check=True,
+                            encoding='utf-8')
+    lines = result.stdout.split("\n")
+
+    regex = re.compile(r'{}\s*=\s*"([\w.-]+)"'.format(field))
+    for line in lines:
+        search = regex.search(line)
+        if search:
+            return search.group(1)
+
+
+def state_changes_for_module(module, statefile):
+    """
+    Compute the Terraform state changes (deletions and moves) for a single
+    project-factory module.
+    """
+    commands = []
+
+    migration = ProjectServicesMigration(module, statefile)
+
+    for (old, new, id) in migration.moves():
+        argv = ["terraform", "state", "rm", "-state", statefile, old]
+        commands.append(argv)
+        argv = ["terraform", "import", "-state", statefile, new, id]
+        commands.append(argv)
+
+    return commands
+
+
+def migrate(statefile, dryrun=False):
+    """
+    Migrate the terraform state in `statefile` to match the post-refactor
+    resource structure.
+    """
+
+    # Generate a list of Terraform resource states from the output of
+    # `terraform state list`
+    resources = [
+        TerraformResource.from_path(path)
+        for path in read_state(statefile)
+    ]
+
+    # Group resources based on the module where they're defined.
+    modules = group_by_module(resources)
+
+    # Filter our list of Terraform modules down to anything that lookst like a
+    # project-factory module. We key this off the presence off of
+    # `random_id.random_project_id_suffix` since that should almost always be
+    # unique to a project-factory module.
+    factories = [
+        module for module in modules
+        if module.has_resource("random_id", "random_project_id_suffix")
+        and module.has_resource("google_project_service", "project_services[0]")
+    ]
+
+    print("---- Migrating the following project-factory modules:")
+
+    # Collect a list of resources for each project factory that need to be
+    # migrated.
+    commands = []
+    for factory in factories:
+        print("-- " + factory.name)
+        commands += state_changes_for_module(factory, statefile)
+
+    for argv in commands:
+        if dryrun:
+            print(" ".join(argv))
+        else:
+            subprocess.run(argv, check=True, encoding='utf-8')
+
+
+def main(argv):
+    parser = argparser()
+    args = parser.parse_args(argv[1:])
+
+    print("cp {} {}".format(args.oldstate, args.newstate))
+    shutil.copy(args.oldstate, args.newstate)
+
+    migrate(args.newstate, dryrun=args.dryrun)
+    print("State migration complete, verify migration with "
+          "`terraform plan -state '{}'`".format(args.newstate))
+
+
+def argparser():
+    parser = argparse.ArgumentParser(description='Migrate Terraform state')
+    parser.add_argument('oldstate', metavar='oldstate.json',
+                        help='The current Terraform state (will not be '
+                             'modified)')
+    parser.add_argument('newstate', metavar='newstate.json',
+                        help='The path to the new state file')
+    parser.add_argument('--dryrun', action='store_true',
+                        help='Print the `terraform state mv` commands instead '
+                             'of running the commands.')
+    return parser
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,6 @@ module "project-factory" {
   folder_id                   = var.folder_id
   sa_role                     = var.sa_role
   activate_apis               = var.activate_apis
-  apis_authority              = var.apis_authority
   usage_bucket_name           = var.usage_bucket_name
   usage_bucket_prefix         = var.usage_bucket_prefix
   credentials_path            = var.credentials_path

--- a/modules/core_project_factory/main.tf
+++ b/modules/core_project_factory/main.tf
@@ -150,24 +150,14 @@ resource "google_resource_manager_lien" "lien" {
 /******************************************
   APIs configuration
  *****************************************/
-resource "google_project_service" "project_services" {
-  count = var.apis_authority ? 0 : length(local.activate_apis)
+module "project_services" {
+  source = "../project_services"
 
-  project = google_project.main.project_id
-  service = element(local.activate_apis, count.index)
+  project_id    = google_project.main.project_id
+  activate_apis = local.activate_apis
 
-  disable_on_destroy         = var.disable_services_on_destroy
-  disable_dependent_services = var.disable_dependent_services
-
-  depends_on = [google_project.main]
-}
-
-resource "google_project_services" "project_services_authority" {
-  count = var.apis_authority ? 1 : 0
-
-  project    = google_project.main.project_id
-  services   = local.activate_apis
-  depends_on = [google_project.main]
+  disable_services_on_destroy = var.disable_services_on_destroy
+  disable_dependent_services  = var.disable_dependent_services
 }
 
 /******************************************
@@ -180,8 +170,7 @@ resource "google_compute_shared_vpc_service_project" "shared_vpc_attachment" {
   service_project = google_project.main.project_id
 
   depends_on = [
-    google_project_service.project_services,
-    google_project_services.project_services_authority,
+    module.project_services,
   ]
 }
 
@@ -217,8 +206,7 @@ EOD
   }
 
   depends_on = [
-    google_project_service.project_services,
-    google_project_services.project_services_authority
+    module.project_services,
   ]
 }
 
@@ -245,8 +233,7 @@ EOD
   }
 
   depends_on = [
-    google_project_service.project_services,
-    google_project_services.project_services_authority
+    module.project_services,
   ]
 }
 
@@ -305,8 +292,7 @@ resource "google_project_iam_member" "controlling_group_vpc_membership" {
   member  = element(local.shared_vpc_users, count.index)
 
   depends_on = [
-    google_project_service.project_services,
-    google_project_services.project_services_authority,
+    module.project_services,
   ]
 }
 
@@ -379,8 +365,7 @@ resource "google_compute_subnetwork_iam_member" "apis_service_account_role_to_vp
   member  = local.api_s_account_fmt
 
   depends_on = [
-    google_project_service.project_services,
-    google_project_services.project_services_authority,
+    module.project_services,
   ]
 }
 
@@ -395,8 +380,7 @@ resource "google_project_usage_export_bucket" "usage_report_export" {
   prefix      = var.usage_bucket_prefix != "" ? var.usage_bucket_prefix : "usage-${google_project.main.project_id}"
 
   depends_on = [
-    google_project_service.project_services,
-    google_project_services.project_services_authority,
+    module.project_services,
   ]
 }
 
@@ -444,8 +428,7 @@ resource "google_storage_bucket_iam_member" "api_s_account_storage_admin_on_proj
   member = local.api_s_account_fmt
 
   depends_on = [
-    google_project_service.project_services,
-    google_project_services.project_services_authority,
+    module.project_services,
   ]
 }
 
@@ -471,8 +454,7 @@ resource "google_compute_subnetwork_iam_member" "gke_shared_vpc_subnets" {
   member  = local.gke_s_account_fmt
 
   depends_on = [
-    google_project_service.project_services,
-    google_project_services.project_services_authority,
+    module.project_services,
   ]
 }
 
@@ -485,8 +467,7 @@ resource "google_project_iam_member" "gke_host_agent" {
   role    = "roles/container.hostServiceAgentUser"
   member  = local.gke_s_account_fmt
   depends_on = [
-    google_project_service.project_services,
-    google_project_services.project_services_authority,
+    module.project_services,
   ]
 }
 

--- a/modules/core_project_factory/outputs.tf
+++ b/modules/core_project_factory/outputs.tf
@@ -21,8 +21,7 @@ output "project_name" {
 output "project_id" {
   value = element(
     concat(
-      google_project_service.project_services.*.project,
-      google_project_services.project_services_authority.*.project,
+      [module.project_services.project_id],
       [google_project.main.project_id],
     ),
     0,

--- a/modules/core_project_factory/variables.tf
+++ b/modules/core_project_factory/variables.tf
@@ -83,12 +83,6 @@ variable "sa_role" {
   default     = ""
 }
 
-variable "apis_authority" {
-  description = "Toggles authoritative management of project services."
-  type        = bool
-  default     = false
-}
-
 variable "activate_apis" {
   description = "The list of apis to activate within the project"
   type        = list(string)

--- a/modules/fabric-project/main.tf
+++ b/modules/fabric-project/main.tf
@@ -37,11 +37,11 @@ resource "google_project" "project" {
   labels              = var.labels
 }
 
-resource "google_project_services" "services" {
-  count   = length(var.activate_apis) > 0 ? 1 : 0
-  project = google_project.project.project_id
+module "project_services" {
+  source = "../project_services"
 
-  services = var.activate_apis
+  project_id    = google_project.project.project_id
+  activate_apis = var.activate_apis
 }
 
 # this will fail for external users, who need to be manually added so they
@@ -74,7 +74,7 @@ resource "google_compute_project_metadata_item" "oslogin_meta" {
   value   = "TRUE"
 
   # depend on services or it will fail on destroy
-  depends_on = [google_project_services.services]
+  depends_on = [module.project_services]
 }
 
 resource "google_project_iam_member" "oslogin_admins" {

--- a/modules/gsuite_enabled/README.md
+++ b/modules/gsuite_enabled/README.md
@@ -60,7 +60,6 @@ The roles granted are specifically:
 |------|-------------|:----:|:-----:|:-----:|
 | activate\_apis | The list of apis to activate within the project | list(string) | `<list>` | no |
 | api\_sa\_group | A GSuite group to place the Google APIs Service Account for the project in | string | `""` | no |
-| apis\_authority | Toggles authoritative management of project services. | string | `"false"` | no |
 | auto\_create\_network | Create the default network | string | `"false"` | no |
 | billing\_account | The ID of the billing account to associate this project with | string | n/a | yes |
 | bucket\_location | The location for a GCS bucket to create (optional) | string | `""` | no |

--- a/modules/gsuite_enabled/main.tf
+++ b/modules/gsuite_enabled/main.tf
@@ -84,7 +84,6 @@ module "project-factory" {
   folder_id                   = var.folder_id
   sa_role                     = var.sa_role
   activate_apis               = var.activate_apis
-  apis_authority              = var.apis_authority
   usage_bucket_name           = var.usage_bucket_name
   usage_bucket_prefix         = var.usage_bucket_prefix
   credentials_path            = var.credentials_path

--- a/modules/gsuite_enabled/variables.tf
+++ b/modules/gsuite_enabled/variables.tf
@@ -89,11 +89,6 @@ variable "activate_apis" {
   default     = ["compute.googleapis.com"]
 }
 
-variable "apis_authority" {
-  description = "Toggles authoritative management of project services."
-  default     = "false"
-}
-
 variable "usage_bucket_name" {
   description = "Name of a GCS bucket to store GCE usage reports in (optional)"
   default     = ""

--- a/modules/project_services/main.tf
+++ b/modules/project_services/main.tf
@@ -18,9 +18,9 @@
   APIs configuration
  *****************************************/
 resource "google_project_service" "project_services" {
-  count                      = var.enable_apis ? length(var.activate_apis) : 0
+  for_each                   = toset([for api in var.activate_apis : api if var.enable_apis])
   project                    = var.project_id
-  service                    = element(var.activate_apis, count.index)
+  service                    = each.value
   disable_on_destroy         = var.disable_services_on_destroy
   disable_dependent_services = var.disable_dependent_services
 }

--- a/modules/project_services/outputs.tf
+++ b/modules/project_services/outputs.tf
@@ -16,9 +16,6 @@
 
 output "project_id" {
   description = "The GCP project you want to enable APIs on"
-  value = element(
-    concat(google_project_service.project_services.*.project, [""]),
-    0,
-  )
+  value       = var.enable_apis && length(var.activate_apis) > 0 ? var.project_id : ""
 }
 

--- a/modules/project_services/outputs.tf
+++ b/modules/project_services/outputs.tf
@@ -16,6 +16,9 @@
 
 output "project_id" {
   description = "The GCP project you want to enable APIs on"
-  value       = var.enable_apis && length(var.activate_apis) > 0 ? var.project_id : ""
+  value = element(
+    [for v in google_project_service.project_services : v.project],
+    0,
+  )
 }
 

--- a/modules/shared_vpc/main.tf
+++ b/modules/shared_vpc/main.tf
@@ -42,7 +42,6 @@ module "project-factory" {
   folder_id                   = var.folder_id
   sa_role                     = var.sa_role
   activate_apis               = var.activate_apis
-  apis_authority              = var.apis_authority
   usage_bucket_name           = var.usage_bucket_name
   usage_bucket_prefix         = var.usage_bucket_prefix
   credentials_path            = var.credentials_path

--- a/modules/shared_vpc/variables.tf
+++ b/modules/shared_vpc/variables.tf
@@ -76,12 +76,6 @@ variable "sa_role" {
   default     = ""
 }
 
-variable "apis_authority" {
-  description = "Toggles authoritative management of project services."
-  type        = bool
-  default     = false
-}
-
 variable "activate_apis" {
   description = "The list of apis to activate within the project"
   type        = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -77,12 +77,6 @@ variable "sa_role" {
   default     = ""
 }
 
-variable "apis_authority" {
-  description = "Toggles authoritative management of project services."
-  type        = bool
-  default     = false
-}
-
 variable "activate_apis" {
   description = "The list of apis to activate within the project"
   type        = list(string)


### PR DESCRIPTION
Convert the project_services module to use for_each instead of count,
and use that module in the core project factory.

Remove the var.apis_authority option.

Add to helpers/migrate.py to also convert this project services
migration. The old GSuite migration will still work. To make this
migration work, it needs to read a value from a resource, which means
calling terraform state show, which is slow.

This is heavily blocked by hashicorp/terraform#22301, as the migrate
script fails to state move the instances of count to instances of
for_each without the for_each resource existing first. As it is, the
migrate script fails with this error:
```
Cannot move to
module.my-project.module.project-factory.module.project_services.google_project_service.project_services["cloudbilling.googleapis.com"]:
module.my-project.module.project-factory.module.project_services.google_project_service.project_services
does not exist in the current state.
```

This is also partially blocked by hashicorp/terraform#10462. As this
moved the project services into a module, the depends_on in the
project_service resource block can't be used in the module block because
of this issue. Since the project_id parameter is referencing the
google_project, it might still work correctly.

Resolves #282