### PR TITLE
Passing impersonate_service_account through to core module

### DIFF
--- a/modules/gsuite_enabled/main.tf
+++ b/modules/gsuite_enabled/main.tf
@@ -88,6 +88,7 @@ module "project-factory" {
   usage_bucket_name           = var.usage_bucket_name
   usage_bucket_prefix         = var.usage_bucket_prefix
   credentials_path            = var.credentials_path
+  impersonate_service_account = var.impersonate_service_account
   shared_vpc_subnets          = var.shared_vpc_subnets
   labels                      = var.labels
   bucket_project              = var.bucket_project

--- a/modules/gsuite_enabled/variables.tf
+++ b/modules/gsuite_enabled/variables.tf
@@ -109,6 +109,12 @@ variable "credentials_path" {
   default     = ""
 }
 
+variable "impersonate_service_account" {
+  description = "An optional service account to impersonate. If this service account is not specified, Terraform will fall back to credential file or Application Default Credentials."
+  type        = string
+  default     = ""
+}
+
 variable "shared_vpc_subnets" {
   description = "List of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id)"
   type        = list(string)


### PR DESCRIPTION
Passes impersonate_service_account through to the core module from gsuite_enabled module.

Fixes https://github.com/terraform-google-modules/terraform-google-project-factory/issues/285