### PR TITLE
Update terraform binary requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ The core Project Factory solely deals with GCP APIs and does not integrate G Sui
 ## Install
 ### Terraform
 
-Be sure you have the correct Terraform version (0.11.x), you can choose the
+Be sure you have the correct Terraform version (0.12.6+), you can choose the
 binary here:
 
 - https://releases.hashicorp.com/terraform/


### PR DESCRIPTION
The current version of the module requires terraform 0.12.6+.

0.12.6 is the version the introduced `for_each` which is in the [project services resource](https://github.com/terraform-google-modules/terraform-google-project-factory/blob/ac41dd3159b2751e3c2ec362f69c66e20a607c33/modules/project_services/main.tf#L21).