### PR TITLE
Fix module crash on empty api list

### DIFF
--- a/modules/project_services/outputs.tf
+++ b/modules/project_services/outputs.tf
@@ -16,5 +16,5 @@
 
 output "project_id" {
   description = "The GCP project you want to enable APIs on"
-  value       = var.enable_apis ? element([for v in google_project_service.project_services : v.project], 0) : var.project_id
+  value       = element(concat([for v in google_project_service.project_services : v.project], [var.project_id]), 0)
 }


### PR DESCRIPTION
If the activate_apis variable was set to an empty list, the
project_services module would crash on trying to get the 0 index of the
empty list. Fix is to instead of only returning the project id from the
input if the enable_apis is false, just concat that variable to the
list, so if there is nothing else in the list, that is returned.

Fixes #300