### PR TITLE
Add option to disable default compute SA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Extending the adopted spec, each change should have a link to its corresponding 
 
 ## [Unreleased]
 
+### Added
+
+- Option to disable the default compute service account. [#313]
+
 ### Fixed
 
 - Fixed an issue with passing an empty list to activate_apis. [#300]

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ determining that location is as follows:
 | bucket\_name | A name for a GCS bucket to create (in the bucket_project project), useful for Terraform state (optional) | string | `""` | no |
 | bucket\_project | A project to create a GCS bucket (bucket_name) in, useful for Terraform state (optional) | string | `""` | no |
 | credentials\_path | Path to a service account credentials file with rights to run the Project Factory. If this file is absent Terraform will fall back to Application Default Credentials. | string | `""` | no |
-| default\_service\_account | Project default service account setting: can be one of `delete`, `depriviledge`, or `keep`. | string | `"delete"` | no |
+| default\_service\_account | Project default service account setting: can be one of `delete`, `depriviledge`, `disable`, or `keep`. | string | `"delete"` | no |
 | disable\_dependent\_services | Whether services that are enabled and which depend on this service should also be disabled when this service is destroyed. | bool | `"true"` | no |
 | disable\_services\_on\_destroy | Whether project services will be disabled when the resources are destroyed | string | `"true"` | no |
 | domain | The domain name (optional). | string | `""` | no |
@@ -163,7 +163,7 @@ determining that location is as follows:
 
 ### Software
 
--   [gcloud sdk](https://cloud.google.com/sdk/install) >= 206.0.0
+-   [gcloud sdk](https://cloud.google.com/sdk/install) >= 269.0.0
 -   [jq](https://stedolan.github.io/jq/) >= 1.6
 -   [Terraform](https://www.terraform.io/downloads.html) >= 0.12.6
 -   [terraform-provider-google] plugin 2.1.x

--- a/examples/simple_project/README.md
+++ b/examples/simple_project/README.md
@@ -15,7 +15,7 @@ Expected variables:
 |------|-------------|:----:|:-----:|:-----:|
 | billing\_account | The ID of the billing account to associate this project with | string | n/a | yes |
 | credentials\_path | Path to a service account credentials file with rights to run the Project Factory. If this file is absent Terraform will fall back to Application Default Credentials. | string | `""` | no |
-| default\_service\_account | Project default service account setting: can be one of `delete`, `depriviledge`, or `keep`. | string | n/a | yes |
+| default\_service\_account | Project default service account setting: can be one of `delete`, `depriviledge`, `disable`, or `keep`. | string | n/a | yes |
 | organization\_id | The organization id for the associated services | string | n/a | yes |
 
 ## Outputs

--- a/examples/simple_project/variables.tf
+++ b/examples/simple_project/variables.tf
@@ -28,6 +28,6 @@ variable "credentials_path" {
 }
 
 variable "default_service_account" {
-  description = "Project default service account setting: can be one of `delete`, `depriviledge`, or `keep`."
+  description = "Project default service account setting: can be one of `delete`, `depriviledge`, `disable`, or `keep`."
 }
 

--- a/modules/core_project_factory/main.tf
+++ b/modules/core_project_factory/main.tf
@@ -238,6 +238,33 @@ EOD
 }
 
 /******************************************
+  Default compute service account disable
+ *****************************************/
+resource "null_resource" "disable_default_compute_service_account" {
+  count = var.default_service_account == "disable" ? 1 : 0
+
+  provisioner "local-exec" {
+    command = <<EOD
+${path.module}/scripts/modify-service-account.sh \
+  --project_id='${google_project.main.project_id}' \
+  --sa_id='${data.null_data_source.default_service_account.outputs["email"]}' \
+  --credentials_path='${var.credentials_path}' \
+  --impersonate-service-account='${var.impersonate_service_account}' \
+  --action='disable'
+EOD
+  }
+
+  triggers = {
+    default_service_account = data.null_data_source.default_service_account.outputs["email"]
+    activated_apis          = join(",", local.activate_apis)
+  }
+
+  depends_on = [
+    module.project_services,
+  ]
+}
+
+/******************************************
   Default Service Account configuration
  *****************************************/
 resource "google_service_account" "default_service_account" {

--- a/modules/core_project_factory/scripts/modify-service-account.sh
+++ b/modules/core_project_factory/scripts/modify-service-account.sh
@@ -92,12 +92,32 @@ depriviledge_sa() {
   fi
 }
 
+# Function to disable the default service account.
+disable_sa() {
+  SA_LIST_COMMAND="gcloud iam service-accounts list $APPEND_IMPERSONATE --project=$PROJECT_ID"
+  SA_LIST=$(${SA_LIST_COMMAND} || exit 1)
+
+  if [[ $SA_LIST = *"$SA_ID"* ]]; then
+      # There is no harm in disabling a service account that is already disabled
+      # Google agrees in their docs
+      echo "Disabling service account $SA_ID in project $PROJECT_ID"
+      SA_DISABLE_COMMAND="gcloud iam service-accounts disable \
+      --quiet $APPEND_IMPERSONATE \
+      --project=$PROJECT_ID $SA_ID"
+      ${SA_DISABLE_COMMAND}
+  else
+      echo "Service account not listed. It appears to have been deleted."
+  fi
+}
+
 # Perform specified action of default service account.
 case $SA_ACTION in
   delete)
       delete_sa ;;
   depriviledge)
       depriviledge_sa ;;
+  disable)
+      disable_sa ;;
   keep)
       echo "Default service account set to keep, nothing to do."
       ;;

--- a/modules/core_project_factory/variables.tf
+++ b/modules/core_project_factory/variables.tf
@@ -156,7 +156,7 @@ variable "disable_services_on_destroy" {
 }
 
 variable "default_service_account" {
-  description = "Project default service account setting: can be one of `delete`, `depriviledge`, or `keep`."
+  description = "Project default service account setting: can be one of `delete`, `depriviledge`, `disable`, or `keep`."
   default     = "delete"
   type        = string
 }

--- a/modules/gsuite_enabled/README.md
+++ b/modules/gsuite_enabled/README.md
@@ -67,7 +67,7 @@ The roles granted are specifically:
 | bucket\_project | A project to create a GCS bucket (bucket_name) in, useful for Terraform state (optional) | string | `""` | no |
 | create\_group | Whether to create the group or not | bool | `"false"` | no |
 | credentials\_path | Path to a service account credentials file with rights to run the Project Factory. If this file is absent Terraform will fall back to Application Default Credentials. | string | `""` | no |
-| default\_service\_account | Project default service account setting: can be one of `delete`, `depriviledge`, or `keep`. | string | `"delete"` | no |
+| default\_service\_account | Project default service account setting: can be one of `delete`, `depriviledge`, `disable`, or `keep`. | string | `"delete"` | no |
 | disable\_dependent\_services | Whether services that are enabled and which depend on this service should also be disabled when this service is destroyed. | string | `"true"` | no |
 | disable\_services\_on\_destroy | Whether project services will be disabled when the resources are destroyed | string | `"true"` | no |
 | domain | The domain name (optional). | string | `""` | no |

--- a/modules/gsuite_enabled/variables.tf
+++ b/modules/gsuite_enabled/variables.tf
@@ -154,7 +154,7 @@ variable "disable_services_on_destroy" {
 }
 
 variable "default_service_account" {
-  description = "Project default service account setting: can be one of `delete`, `depriviledge`, or `keep`."
+  description = "Project default service account setting: can be one of `delete`, `depriviledge`, `disable`, or `keep`."
   default     = "delete"
   type        = string
 }

--- a/modules/shared_vpc/variables.tf
+++ b/modules/shared_vpc/variables.tf
@@ -148,7 +148,7 @@ variable "disable_services_on_destroy" {
 }
 
 variable "default_service_account" {
-  description = "Project default service account setting: can be one of `delete`, `depriviledge`, or `keep`."
+  description = "Project default service account setting: can be one of `delete`, `depriviledge`, `disable`, or `keep`."
   default     = "delete"
   type        = string
 }

--- a/test/fixtures/full/README.md
+++ b/test/fixtures/full/README.md
@@ -27,6 +27,7 @@
 
 | Name | Description |
 |------|-------------|
+| compute\_service\_account\_email |  |
 | domain |  |
 | extra\_service\_account\_email |  |
 | group\_email |  |

--- a/test/fixtures/full/main.tf
+++ b/test/fixtures/full/main.tf
@@ -119,6 +119,7 @@ module "project-factory" {
     "container.googleapis.com",
   ]
 
+  default_service_account     = "delete"
   disable_services_on_destroy = "false"
 }
 

--- a/test/fixtures/minimal/README.md
+++ b/test/fixtures/minimal/README.md
@@ -26,6 +26,7 @@
 
 | Name | Description |
 |------|-------------|
+| compute\_service\_account\_email |  |
 | domain |  |
 | group\_email |  |
 | group\_role |  |

--- a/test/fixtures/minimal/main.tf
+++ b/test/fixtures/minimal/main.tf
@@ -37,6 +37,7 @@ module "project-factory" {
     "container.googleapis.com",
   ]
 
+  default_service_account     = "disable"
   disable_services_on_destroy = "false"
 }
 

--- a/test/fixtures/shared/outputs.tf
+++ b/test/fixtures/shared/outputs.tf
@@ -42,6 +42,10 @@ output "service_account_email" {
   value = module.project-factory.service_account_email
 }
 
+output "compute_service_account_email" {
+  value = "${module.project-factory.project_number}-compute@developer.gserviceaccount.com"
+}
+
 output "gsuite_admin_account" {
   value = var.gsuite_admin_account
 }

--- a/test/integration/full/controls/project-factory.rb
+++ b/test/integration/full/controls/project-factory.rb
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-extra_service_account_email = attribute('extra_service_account_email')
-project_name                = attribute('project_name')
-project_id                  = attribute('project_id')
-sa_role                     = attribute('sa_role')
-service_account_email       = attribute('service_account_email')
-usage_bucket_name           = attribute('usage_bucket_name')
-usage_bucket_prefix         = attribute('usage_bucket_prefix')
+extra_service_account_email   = attribute('extra_service_account_email')
+compute_service_account_email = attribute('compute_service_account_email')
+project_name                  = attribute('project_name')
+project_id                    = attribute('project_id')
+sa_role                       = attribute('sa_role')
+service_account_email         = attribute('service_account_email')
+usage_bucket_name             = attribute('usage_bucket_name')
+usage_bucket_prefix           = attribute('usage_bucket_prefix')
 
 # Set a reasonable default value for `usage_bucket_prefix` if the Terraform
 # provided value is empty.
@@ -69,6 +70,10 @@ control 'project-factory' do
 
     it "includes the service account created outside of the project factory" do
       expect(service_accounts).to include extra_service_account_email
+    end
+
+    it "does not include the default compute service account" do
+      expect(service_accounts).not_to include compute_service_account_email
     end
   end
 

--- a/test/integration/full/inspec.yml
+++ b/test/integration/full/inspec.yml
@@ -20,6 +20,10 @@ attributes:
     required: true
     type: string
 
+  - name: compute_service_account_email
+    required: true
+    type: string
+
   - name: sa_role
     required: false
     default: null

--- a/test/integration/minimal/inspec.yml
+++ b/test/integration/minimal/inspec.yml
@@ -9,6 +9,9 @@ attributes:
   - name: service_account_email
     required: true
 
+  - name: compute_service_account_email
+    required: true
+
   - name: group_email
     required: true
 

--- a/variables.tf
+++ b/variables.tf
@@ -156,7 +156,7 @@ variable "disable_services_on_destroy" {
 }
 
 variable "default_service_account" {
-  description = "Project default service account setting: can be one of `delete`, `depriviledge`, or `keep`."
+  description = "Project default service account setting: can be one of `delete`, `depriviledge`, `disable`, or `keep`."
   default     = "delete"
   type        = string
 }


### PR DESCRIPTION
Disabling instead of deleting the default service account achieves the
same result: the service account no longer works. But disabling is
possible to undo at any time, where after 30 days a deleted account is
unrecoverable.

I have tested this with creating a new project, and it works as expected.

Thoughts about making this the default instead of delete?

Resolves #313