### PR TITLE
Change default for default compute SA to disable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Extending the adopted spec, each change should have a link to its corresponding 
 
 - Option to disable the default compute service account. [#313]
 
+### Changed
+
+- **Breaking**: Default for default compute service account changed to disable from delete. [#313]
+
 ### Fixed
 
 - Fixed an issue with passing an empty list to activate_apis. [#300]

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ determining that location is as follows:
 | bucket\_name | A name for a GCS bucket to create (in the bucket_project project), useful for Terraform state (optional) | string | `""` | no |
 | bucket\_project | A project to create a GCS bucket (bucket_name) in, useful for Terraform state (optional) | string | `""` | no |
 | credentials\_path | Path to a service account credentials file with rights to run the Project Factory. If this file is absent Terraform will fall back to Application Default Credentials. | string | `""` | no |
-| default\_service\_account | Project default service account setting: can be one of `delete`, `depriviledge`, `disable`, or `keep`. | string | `"delete"` | no |
+| default\_service\_account | Project default service account setting: can be one of `delete`, `depriviledge`, `disable`, or `keep`. | string | `"disable"` | no |
 | disable\_dependent\_services | Whether services that are enabled and which depend on this service should also be disabled when this service is destroyed. | bool | `"true"` | no |
 | disable\_services\_on\_destroy | Whether project services will be disabled when the resources are destroyed | string | `"true"` | no |
 | domain | The domain name (optional). | string | `""` | no |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -249,7 +249,7 @@ requires that the default compute service account be in place in the project.
 **Solution:**
 
 In order to deploy an App Engine Flex application into a project created by Project Factory,
-the default service account must not be deleted (as is the default behavior). To prevent the
+the default service account must not be disabled (as is the default behavior) or deleted. To prevent the
 default service account from being deleted, ensure that the `default_service_account` input
 is set to either `depriviledge` or `keep`.
 

--- a/modules/core_project_factory/variables.tf
+++ b/modules/core_project_factory/variables.tf
@@ -157,7 +157,7 @@ variable "disable_services_on_destroy" {
 
 variable "default_service_account" {
   description = "Project default service account setting: can be one of `delete`, `depriviledge`, `disable`, or `keep`."
-  default     = "delete"
+  default     = "disable"
   type        = string
 }
 

--- a/modules/gsuite_enabled/README.md
+++ b/modules/gsuite_enabled/README.md
@@ -67,7 +67,7 @@ The roles granted are specifically:
 | bucket\_project | A project to create a GCS bucket (bucket_name) in, useful for Terraform state (optional) | string | `""` | no |
 | create\_group | Whether to create the group or not | bool | `"false"` | no |
 | credentials\_path | Path to a service account credentials file with rights to run the Project Factory. If this file is absent Terraform will fall back to Application Default Credentials. | string | `""` | no |
-| default\_service\_account | Project default service account setting: can be one of `delete`, `depriviledge`, `disable`, or `keep`. | string | `"delete"` | no |
+| default\_service\_account | Project default service account setting: can be one of `delete`, `depriviledge`, `disable`, or `keep`. | string | `"disable"` | no |
 | disable\_dependent\_services | Whether services that are enabled and which depend on this service should also be disabled when this service is destroyed. | string | `"true"` | no |
 | disable\_services\_on\_destroy | Whether project services will be disabled when the resources are destroyed | string | `"true"` | no |
 | domain | The domain name (optional). | string | `""` | no |

--- a/modules/gsuite_enabled/variables.tf
+++ b/modules/gsuite_enabled/variables.tf
@@ -155,7 +155,7 @@ variable "disable_services_on_destroy" {
 
 variable "default_service_account" {
   description = "Project default service account setting: can be one of `delete`, `depriviledge`, `disable`, or `keep`."
-  default     = "delete"
+  default     = "disable"
   type        = string
 }
 

--- a/modules/shared_vpc/variables.tf
+++ b/modules/shared_vpc/variables.tf
@@ -149,7 +149,7 @@ variable "disable_services_on_destroy" {
 
 variable "default_service_account" {
   description = "Project default service account setting: can be one of `delete`, `depriviledge`, `disable`, or `keep`."
-  default     = "delete"
+  default     = "disable"
   type        = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -157,7 +157,7 @@ variable "disable_services_on_destroy" {
 
 variable "default_service_account" {
   description = "Project default service account setting: can be one of `delete`, `depriviledge`, `disable`, or `keep`."
-  default     = "delete"
+  default     = "disable"
   type        = string
 }
 


### PR DESCRIPTION
This is a better option than "delete", since it has the same outcome
(the account doesn't work), but it is possible to get the account back,
unlike which delete which can be unrecoverable. This then should be the
default, since it achieves the same outcome, but is completely and
easily reversible for those that realize they don't want the default
later on.

Related #313, #314 