### PR TITLE
Deprivilege before deleting service account

### DIFF
--- a/modules/core_project_factory/scripts/modify-service-account.sh
+++ b/modules/core_project_factory/scripts/modify-service-account.sh
@@ -113,6 +113,7 @@ disable_sa() {
 # Perform specified action of default service account.
 case $SA_ACTION in
   delete)
+      depriviledge_sa
       delete_sa ;;
   depriviledge)
       depriviledge_sa ;;


### PR DESCRIPTION
When `default_service_account`=`delete`, deprivilege first to remove IAM binding before deleting the service account.

Fixes #339 