### PR TITLE
relax google provider versioning. Allow for 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Extending the adopted spec, each change should have a link to its corresponding 
 
 ## [Unreleased]
 
+### Changed
+
+- Changed required `google` provider version to `>= 2.1, < 4.0` [#350]
+
 ## [6.2.0] - 2019-12-27
 
 ### Added
@@ -306,6 +310,7 @@ Extending the adopted spec, each change should have a link to its corresponding 
 [0.2.1]: https://github.com/terraform-google-modules/terraform-google-project-factory/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/terraform-google-modules/terraform-google-project-factory/compare/v0.1.0...v0.2.0
 
+[#350]: https://github.com/terraform-google-modules/terraform-google-project-factory/issues/350
 [#343]: https://github.com/terraform-google-modules/terraform-google-project-factory/issues/343
 [#345]: https://github.com/terraform-google-modules/terraform-google-project-factory/pull/345
 [#341]: https://github.com/terraform-google-modules/terraform-google-project-factory/pull/341

--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ determining that location is as follows:
 -   [gcloud sdk](https://cloud.google.com/sdk/install) >= 269.0.0
 -   [jq](https://stedolan.github.io/jq/) >= 1.6
 -   [Terraform](https://www.terraform.io/downloads.html) >= 0.12.6
--   [terraform-provider-google] plugin 2.1.x
--   [terraform-provider-google-beta] plugin 2.1.x
+-   [terraform-provider-google] plugin >= 2.1, < 4.0
+-   [terraform-provider-google-beta] plugin >= 2.1, < 4.0
 -   [terraform-provider-gsuite] plugin 0.1.x if GSuite functionality is desired
 
 ### Permissions
@@ -233,7 +233,7 @@ credentials to pass to these scripts. Credentials can be provided via two mechan
     ```terraform
     provider "google" {
       credentials = "${file(var.credentials_path)}"
-      version = "~> 1.20"
+      version = "~> 3.3"
     }
 
     module "project-factory" {
@@ -251,7 +251,7 @@ credentials to pass to these scripts. Credentials can be provided via two mechan
    provider "google" {
      # Terraform will check the `GOOGLE_APPLICATION_CREDENTIALS` variable, so no `credentials`
      # value is needed here.
-      version = "~> 1.20"
+      version = "~> 3.3"
    }
 
    module "project-factory" {

--- a/examples/simple_project/main.tf
+++ b/examples/simple_project/main.tf
@@ -23,12 +23,12 @@ locals {
  *****************************************/
 provider "google" {
   credentials = file(local.credentials_file_path)
-  version     = "~> 2.18.1"
+  version     = "~> 3.3.0"
 }
 
 provider "google-beta" {
   credentials = file(local.credentials_file_path)
-  version     = "~> 2.18.1"
+  version     = "~> 3.3.0"
 }
 
 provider "null" {

--- a/modules/app_engine/versions.tf
+++ b/modules/app_engine/versions.tf
@@ -18,6 +18,6 @@ terraform {
   required_version = "~> 0.12.6"
 
   required_providers {
-    google = "~> 2.1"
+    google = ">= 2.1, < 4.0"
   }
 }

--- a/modules/core_project_factory/versions.tf
+++ b/modules/core_project_factory/versions.tf
@@ -18,8 +18,8 @@ terraform {
   required_version = "~> 0.12.6"
 
   required_providers {
-    google      = "~> 2.1"
-    google-beta = "~> 2.1"
+    google      = ">= 2.1, < 4.0"
+    google-beta = ">= 2.1, < 4.0"
     null        = "~> 2.1"
     random      = "~> 2.2"
   }

--- a/modules/gsuite_group/versions.tf
+++ b/modules/gsuite_group/versions.tf
@@ -18,6 +18,6 @@ terraform {
   required_version = "~> 0.12.6"
 
   required_providers {
-    google = "~> 2.1"
+    google = ">= 2.1, < 4.0"
   }
 }

--- a/modules/project_services/versions.tf
+++ b/modules/project_services/versions.tf
@@ -18,6 +18,6 @@ terraform {
   required_version = "~> 0.12.6"
 
   required_providers {
-    google = "~> 2.1"
+    google = ">= 2.1, < 4.0"
   }
 }

--- a/test/fixtures/minimal/main.tf
+++ b/test/fixtures/minimal/main.tf
@@ -15,11 +15,11 @@
  */
 
 provider "google" {
-  version = "~> 2.18.1"
+  version = "~> 3.3.0"
 }
 
 provider "google-beta" {
-  version = "~> 2.18.1"
+  version = "~> 3.3.0"
 }
 
 provider "null" {


### PR DESCRIPTION
Fixes #346 

- Updated provider version in all modules to `>= 2.1, < 4.0`
- Updated example and simple test to use current 3.3.0 version
- Verified on [Upgrade Guide](https://www.terraform.io/docs/providers/google/guides/version_3_upgrade.html) that all resources and configs in all modules don't have backwards incompatible setups. 