### PR TITLE
Directly link to the glossary for seed project/SA

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,9 @@ following roles:
 #### Script Helper
 
 A [helper script](./helpers/setup-sa.sh) is included to create the Seed Service
-Account in the Seed Project, grant the necessary roles to the Seed Service
-Account, and enable the necessary API's in the Seed Project.  Run it as follows:
+Account in the [Seed Project](https://github.com/terraform-google-modules/terraform-google-project-factory/blob/master/docs/GLOSSARY.md#seed-project),
+grant the necessary roles to the [Seed Service Account](https://github.com/terraform-google-modules/terraform-google-project-factory/blob/master/docs/GLOSSARY.md#seed-service-account),
+and enable the necessary API's in the Seed Project.  Run it as follows:
 
 ```sh
 ./helpers/setup-sa.sh <ORGANIZATION_ID> <SEED_PROJECT_NAME> [BILLING_ACCOUNT]


### PR DESCRIPTION
We got a question about what a seed project is in Slack, and the glossary is a little hard to spot once you're already reading the docs.