### PR TITLE
chore: Add a test fixture to validate dynamic Shared VPC

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -47,6 +47,11 @@ suites:
       name: terraform
       command_timeout: 1800
       root_module_directory: test/fixtures/budget
+  - name: dynamic_shared_vpc
+    driver:
+      name: terraform
+      command_timeout: 1800
+      root_module_directory: test/fixtures/dynamic_shared_vpc
 # Disabled due to issue #275
 # (https://github.com/terraform-google-modules/terraform-google-project-factory/issues/275)
 #  - name: full

--- a/examples/shared_vpc/README.md
+++ b/examples/shared_vpc/README.md
@@ -10,17 +10,21 @@ It includes creating the host project and using the [network module](https://git
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | billing\_account | The ID of the billing account to associate this project with | string | n/a | yes |
-| credentials\_path | Path to a Service Account credentials file with permissions documented in the readme | string | n/a | yes |
+| folder\_id | The folder to create projects in | string | n/a | yes |
 | host\_project\_name | Name for Shared VPC host project | string | `"shared-vpc-host"` | no |
 | network\_name | Name for Shared VPC network | string | `"shared-network"` | no |
 | organization\_id | The organization id for the associated services | string | n/a | yes |
+| service\_project\_name | Name for Shared VPC service project | string | `"shared-vpc-service"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
+| host\_project | The full host project info |
 | host\_project\_id | The ID of the created project |
 | network\_name | The name of the VPC being created |
 | network\_self\_link | The URI of the VPC being created |
+| service\_project | The service project info |
+| vpc | The network info |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/shared_vpc/outputs.tf
+++ b/examples/shared_vpc/outputs.tf
@@ -19,6 +19,21 @@ output "host_project_id" {
   description = "The ID of the created project"
 }
 
+output "host_project" {
+  value       = module.host-project
+  description = "The full host project info"
+}
+
+output "service_project" {
+  value       = module.service-project
+  description = "The service project info"
+}
+
+output "vpc" {
+  value       = module.vpc
+  description = "The network info"
+}
+
 output "network_name" {
   value       = module.vpc.network_name
   description = "The name of the VPC being created"

--- a/modules/core_project_factory/main.tf
+++ b/modules/core_project_factory/main.tf
@@ -158,7 +158,7 @@ data "null_data_source" "default_service_account" {
  *****************************************/
 module "gcloud_delete" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 0.3"
+  version = "~> 0.5.0"
 
   enabled = var.default_service_account == "delete"
 
@@ -183,7 +183,7 @@ module "gcloud_delete" {
  ********************************************/
 module "gcloud_deprivilege" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 0.3"
+  version = "~> 0.5.0"
 
   enabled = var.default_service_account == "deprivilege"
 
@@ -208,7 +208,7 @@ module "gcloud_deprivilege" {
  *****************************************/
 module "gcloud_disable" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 0.3"
+  version = "~> 0.5.0"
 
   enabled = var.default_service_account == "disable"
 

--- a/test/fixtures/dynamic_shared_vpc/main.tf
+++ b/test/fixtures/dynamic_shared_vpc/main.tf
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module "example" {
+  source               = "../../../examples/shared_vpc"
+  organization_id      = var.org_id
+  folder_id            = var.folder_id
+  billing_account      = var.billing_account
+  host_project_name    = "pf-ci-shared2-host-${var.random_string_for_testing}"
+  service_project_name = "pf-ci-shared2-svc-${var.random_string_for_testing}"
+}

--- a/test/fixtures/dynamic_shared_vpc/outputs.tf
+++ b/test/fixtures/dynamic_shared_vpc/outputs.tf
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "service_project_name" {
+  value       = module.example.service_project.project_name
+  description = "The service project name"
+}
+
+output "service_project_id" {
+  value       = module.example.service_project.project_id
+  description = "The service project ID"
+}
+
+output "service_project_number" {
+  value       = module.example.service_project.project_number
+  description = "The service project number"
+}
+
+output "service_account_email" {
+  value       = module.example.service_project.service_account_email
+  description = "The service account email"
+}
+
+output "shared_vpc" {
+  value       = module.example.host_project.project_id
+  description = "The host project ID"
+}
+
+output "shared_vpc_subnet_name_01" {
+  value       = module.example.vpc.subnets_names[0]
+  description = "The first subnet name"
+}
+
+output "shared_vpc_subnet_region_01" {
+  value       = module.example.vpc.subnets_regions[0]
+  description = "The first subnet region"
+}
+
+output "shared_vpc_subnet_name_02" {
+  value       = module.example.vpc.subnets_names[1]
+  description = "The second subnet name"
+}
+
+output "shared_vpc_subnet_region_02" {
+  value       = module.example.vpc.subnets_regions[1]
+  description = "The second subnet region"
+}

--- a/test/fixtures/dynamic_shared_vpc/variables.tf
+++ b/test/fixtures/dynamic_shared_vpc/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google LLC
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,30 +14,24 @@
  * limitations under the License.
  */
 
-variable "organization_id" {
-  description = "The organization id for the associated services"
+variable "org_id" {
+  description = "The organization ID."
+  type        = string
 }
 
 variable "folder_id" {
-  description = "The folder to create projects in"
+  description = "The ID of a folder to host this project."
+  type        = string
+  default     = ""
 }
 
 variable "billing_account" {
   description = "The ID of the billing account to associate this project with"
+  type        = string
 }
 
-variable "host_project_name" {
-  description = "Name for Shared VPC host project"
-  default     = "shared-vpc-host"
-}
-
-variable "service_project_name" {
-  description = "Name for Shared VPC service project"
-  default     = "shared-vpc-service"
-}
-
-variable "network_name" {
-  description = "Name for Shared VPC network"
-  default     = "shared-network"
+variable "random_string_for_testing" {
+  type        = string
+  description = "A random string of characters to be appended to resource names to ensure uniqueness"
 }
 

--- a/test/integration/dynamic_shared_vpc/controls/svpc.rb
+++ b/test/integration/dynamic_shared_vpc/controls/svpc.rb
@@ -1,0 +1,114 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+service_project_id          = attribute('service_project_id')
+service_project_number      = attribute('service_project_number')
+service_account_email       = attribute('service_account_email')
+shared_vpc                  = attribute('shared_vpc')
+shared_vpc_subnet_name_01   = attribute('shared_vpc_subnet_name_01')
+shared_vpc_subnet_region_01 = attribute('shared_vpc_subnet_region_01')
+shared_vpc_subnet_name_02   = attribute('shared_vpc_subnet_name_02')
+shared_vpc_subnet_region_02 = attribute('shared_vpc_subnet_region_02')
+
+control 'project-factory-shared-vpc' do
+  title "Project Factory shared VPC"
+
+  describe command("gcloud compute shared-vpc get-host-project #{service_project_id} --format='get(name)'") do
+    its('exit_status') { should eq 0 }
+    its('stderr') { should eq '' }
+    its('stdout.strip') { should eq shared_vpc }
+  end
+
+  describe command("gcloud projects get-iam-policy #{shared_vpc} --format=json") do
+    its('exit_status') { should eq 0 }
+    its('stderr') { should eq '' }
+
+    let(:bindings) do
+      if subject.exit_status == 0
+        JSON.parse(subject.stdout, symbolize_names: true)[:bindings]
+      else
+        []
+      end
+    end
+
+    describe "roles/compute.networkUser" do
+      it "does not include the project service account in the roles/compute.networkUser IAM binding" do
+        expect(bindings).not_to include(
+          members: including("serviceAccount:#{service_account_email}"),
+          role: "roles/compute.networkUser",
+        )
+      end
+
+      it "does not include the GKE service account in the roles/compute.networkUser IAM binding" do
+        expect(bindings).not_to include(
+          members: including(
+            "serviceAccount:service-#{service_project_number}@container-engine-robot.iam.gserviceaccount.com"
+          ),
+          role: "roles/compute.networkUser",
+        )
+      end
+    end
+
+    it "includes the GKE service account in the roles/container.hostServiceAgentUser IAM binding" do
+      expect(bindings).to include(
+        members: including("serviceAccount:service-#{service_project_number}@container-engine-robot.iam.gserviceaccount.com"),
+        role: "roles/container.hostServiceAgentUser",
+      )
+    end
+  end
+
+  describe command("gcloud beta compute networks subnets get-iam-policy #{shared_vpc_subnet_name_01} --region #{shared_vpc_subnet_region_01} --project #{shared_vpc} --format=json") do
+    its('exit_status') { should eq 0 }
+    its('stderr') { should eq '' }
+
+    let(:bindings) do
+      if subject.exit_status == 0
+        JSON.parse(subject.stdout, symbolize_names: true)[:bindings]
+      else
+        []
+      end
+    end
+
+    describe "roles/compute.networkUser" do
+      it "includes the project service account in the roles/compute.networkUser IAM binding" do
+        expect(bindings).to include(
+          members: including("serviceAccount:#{service_account_email}"),
+          role: "roles/compute.networkUser",
+        )
+      end
+    end
+  end
+
+  describe command("gcloud beta compute networks subnets get-iam-policy #{shared_vpc_subnet_name_02} --region #{shared_vpc_subnet_region_02} --project #{shared_vpc} --format=json") do
+    its('exit_status') { should eq 0 }
+    its('stderr') { should eq '' }
+
+    let(:bindings) do
+      if subject.exit_status == 0
+        JSON.parse(subject.stdout, symbolize_names: true)[:bindings]
+      else
+        []
+      end
+    end
+
+    describe "roles/compute.networkUser" do
+      it "includes the project service account in the roles/compute.networkUser IAM binding" do
+        expect(bindings).to include(
+          members: including("serviceAccount:#{service_account_email}"),
+          role: "roles/compute.networkUser",
+        )
+      end
+    end
+  end
+end

--- a/test/integration/dynamic_shared_vpc/inspec.yml
+++ b/test/integration/dynamic_shared_vpc/inspec.yml
@@ -1,0 +1,29 @@
+name: dynamic_shared_vpc
+attributes:
+  - name: service_project_name
+    required: true
+    type: string
+  - name: service_project_id
+    required: true
+    type: string
+  - name: service_project_number
+    required: true
+    type: string
+  - name: service_account_email
+    required: true
+    type: string
+  - name: shared_vpc
+    required: false
+    default: null
+  - name: shared_vpc_subnet_name_01
+    type: string
+    required: true
+  - name: shared_vpc_subnet_region_01
+    type: string
+    required: true
+  - name: shared_vpc_subnet_name_02
+    type: string
+    required: true
+  - name: shared_vpc_subnet_region_02
+    type: string
+    required: true

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -31,6 +31,7 @@ locals {
     "roles/resourcemanager.folderAdmin",
     "roles/resourcemanager.folderIamAdmin",
     "roles/billing.projectManager",
+    "roles/compute.xpnAdmin"
   ]
 }
 


### PR DESCRIPTION
This should prevent issues from occurring around the dynamically created/managed subnets or shared VPC host projects.