### PR TITLE
Fix shared_vpc_subnets default on gke_shared_vpc example

### DIFF
--- a/examples/gke_shared_vpc/variables.tf
+++ b/examples/gke_shared_vpc/variables.tf
@@ -33,6 +33,6 @@ variable "shared_vpc" {
 variable "shared_vpc_subnets" {
   description = "List of subnets fully qualified subnet IDs (ie. projects/$PROJECT_ID/regions/$REGION/subnetworks/$SUBNET_ID)"
   type        = list(string)
-  default     = [""]
+  default     = []
 }
 


### PR DESCRIPTION
Follow up on #382 to fix issue in example.

Fixes #384