### PR TITLE
Add dependency on service enablement.

### DIFF
--- a/modules/core_project_factory/outputs.tf
+++ b/modules/core_project_factory/outputs.tf
@@ -26,10 +26,12 @@ output "project_id" {
     ),
     0,
   )
+  depends_on = [ module.project_services ]
 }
 
 output "project_number" {
   value = google_project.main.number
+  depends_on = [ module.project_services ]
 }
 
 output "service_account_id" {

--- a/modules/core_project_factory/outputs.tf
+++ b/modules/core_project_factory/outputs.tf
@@ -26,12 +26,12 @@ output "project_id" {
     ),
     0,
   )
-  depends_on = [ module.project_services ]
+  depends_on = [module.project_services]
 }
 
 output "project_number" {
-  value = google_project.main.number
-  depends_on = [ module.project_services ]
+  value      = google_project.main.number
+  depends_on = [module.project_services]
 }
 
 output "service_account_id" {

--- a/test/fixtures/minimal/README.md
+++ b/test/fixtures/minimal/README.md
@@ -15,6 +15,7 @@
 | Name | Description |
 |------|-------------|
 | compute\_service\_account\_email |  |
+| container\_service\_account\_email |  |
 | group\_email |  |
 | project\_id |  |
 | project\_name |  |

--- a/test/fixtures/minimal/main.tf
+++ b/test/fixtures/minimal/main.tf
@@ -47,3 +47,11 @@ module "project-factory" {
   default_service_account     = "disable"
   disable_services_on_destroy = "false"
 }
+
+// Add a binding to the container service robot account to test that the
+// dependency on that service is correctly sequenced.
+resource "google_project_iam_member" "iam-binding" {
+  project = module.project-factory.project_id
+  role    = "roles/container.developer"
+  member  = "serviceAccount:service-${module.project-factory.project_number}@container-engine-robot.iam.gserviceaccount.com"
+}

--- a/test/fixtures/minimal/outputs.tf
+++ b/test/fixtures/minimal/outputs.tf
@@ -34,6 +34,10 @@ output "compute_service_account_email" {
   value = "${module.project-factory.project_number}-compute@developer.gserviceaccount.com"
 }
 
+output "container_service_account_email" {
+  value = "service-${module.project-factory.project_number}@container-engine-robot.iam.gserviceaccount.com"
+}
+
 output "group_email" {
   value = module.project-factory.group_email
 }

--- a/test/integration/minimal/inspec.yml
+++ b/test/integration/minimal/inspec.yml
@@ -12,6 +12,9 @@ attributes:
   - name: compute_service_account_email
     required: true
 
+  - name: container_service_account_email
+    required: true
+
   - name: group_email
     required: true
 


### PR DESCRIPTION
Adds a dependency on project services to the output project id and
number.  This prevents a race for using a robot account based on the
project id or number, as the robot accounts can be created only when
the service enabling is finished.

Fixes #386