### PR TITLE
Add option for skipping the gcloud CLI download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Extending the adopted spec, each change should have a link to its corresponding 
 
 ## [Unreleased]
 
+- Added `skip_gcloud_download` option which can be used to skip downloading the gcloud CLI if it is already installed
+
 ## [7.0.0] - 2020-01-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ determining that location is as follows:
 | sa\_role | A role to give the default Service Account for the project (defaults to none) | string | `""` | no |
 | shared\_vpc | The ID of the host project which hosts the shared VPC | string | `""` | no |
 | shared\_vpc\_subnets | List of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id) | list(string) | `<list>` | no |
+| skip\_gcloud\_download | Whether to skip downloading gcloud (assumes gcloud is already available outside the module) | bool | `"false"` | no |
 | usage\_bucket\_name | Name of a GCS bucket to store GCE usage reports in (optional) | string | `""` | no |
 | usage\_bucket\_prefix | Prefix in the GCS bucket to store GCE usage reports in (optional) | string | `""` | no |
 | use\_tf\_google\_credentials\_env\_var | Use GOOGLE_CREDENTIALS environment variable to run gcloud auth activate-service-account with. | bool | `"false"` | no |

--- a/main.tf
+++ b/main.tf
@@ -58,6 +58,7 @@ module "project-factory" {
   python_interpreter_path           = var.python_interpreter_path
   pip_executable_path               = var.pip_executable_path
   use_tf_google_credentials_env_var = var.use_tf_google_credentials_env_var
+  skip_gcloud_download              = var.skip_gcloud_download
 }
 
 /******************************************

--- a/modules/core_project_factory/main.tf
+++ b/modules/core_project_factory/main.tf
@@ -163,6 +163,8 @@ module "gcloud_delete" {
   enabled                           = var.default_service_account == "delete"
   use_tf_google_credentials_env_var = var.use_tf_google_credentials_env_var
 
+  skip_download = var.skip_gcloud_download
+
   create_cmd_entrypoint = "${path.module}/scripts/modify-service-account.sh"
   create_cmd_body       = <<-EOT
     --project_id='${google_project.main.project_id}' \
@@ -189,6 +191,8 @@ module "gcloud_deprivilege" {
   enabled                           = var.default_service_account == "deprivilege"
   use_tf_google_credentials_env_var = var.use_tf_google_credentials_env_var
 
+  skip_download = var.skip_gcloud_download
+
   create_cmd_entrypoint = "${path.module}/scripts/modify-service-account.sh"
   create_cmd_body       = <<-EOT
     --project_id='${google_project.main.project_id}' \
@@ -214,6 +218,8 @@ module "gcloud_disable" {
 
   enabled                           = var.default_service_account == "disable"
   use_tf_google_credentials_env_var = var.use_tf_google_credentials_env_var
+
+  skip_download = var.skip_gcloud_download
 
   create_cmd_entrypoint = "${path.module}/scripts/modify-service-account.sh"
   create_cmd_body       = <<-EOT

--- a/modules/core_project_factory/variables.tf
+++ b/modules/core_project_factory/variables.tf
@@ -189,3 +189,9 @@ variable "use_tf_google_credentials_env_var" {
   type        = bool
   default     = false
 }
+
+variable "skip_gcloud_download" {
+  description = "Whether to skip downloading gcloud (assumes gcloud is already available outside the module)"
+  type        = bool
+  default     = false
+}

--- a/modules/gsuite_enabled/README.md
+++ b/modules/gsuite_enabled/README.md
@@ -90,6 +90,7 @@ The roles granted are specifically:
 | shared\_vpc | The ID of the host project which hosts the shared VPC | string | `""` | no |
 | shared\_vpc\_enabled | If shared VPC should be used | bool | `"false"` | no |
 | shared\_vpc\_subnets | List of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id) | list(string) | `<list>` | no |
+| skip\_gcloud\_download | Whether to skip downloading gcloud (assumes gcloud is already available outside the module) | bool | `"false"` | no |
 | usage\_bucket\_name | Name of a GCS bucket to store GCE usage reports in (optional) | string | `""` | no |
 | usage\_bucket\_prefix | Prefix in the GCS bucket to store GCE usage reports in (optional) | string | `""` | no |
 | use\_tf\_google\_credentials\_env\_var | Use GOOGLE_CREDENTIALS environment variable to run gcloud auth activate-service-account with. | bool | `"false"` | no |

--- a/modules/gsuite_enabled/main.tf
+++ b/modules/gsuite_enabled/main.tf
@@ -99,6 +99,7 @@ module "project-factory" {
   disable_dependent_services        = var.disable_dependent_services
   python_interpreter_path           = var.python_interpreter_path
   use_tf_google_credentials_env_var = var.use_tf_google_credentials_env_var
+  skip_gcloud_download              = var.skip_gcloud_download
 }
 
 /******************************************

--- a/modules/gsuite_enabled/variables.tf
+++ b/modules/gsuite_enabled/variables.tf
@@ -200,3 +200,9 @@ variable "use_tf_google_credentials_env_var" {
   type        = bool
   default     = false
 }
+
+variable "skip_gcloud_download" {
+  description = "Whether to skip downloading gcloud (assumes gcloud is already available outside the module)"
+  type        = bool
+  default     = false
+}

--- a/modules/shared_vpc/main.tf
+++ b/modules/shared_vpc/main.tf
@@ -56,6 +56,7 @@ module "project-factory" {
   disable_dependent_services        = var.disable_dependent_services
   python_interpreter_path           = var.python_interpreter_path
   use_tf_google_credentials_env_var = var.use_tf_google_credentials_env_var
+  skip_gcloud_download              = var.skip_gcloud_download
 }
 
 /******************************************

--- a/modules/shared_vpc/variables.tf
+++ b/modules/shared_vpc/variables.tf
@@ -194,3 +194,9 @@ variable "use_tf_google_credentials_env_var" {
   type        = bool
   default     = false
 }
+
+variable "skip_gcloud_download" {
+  description = "Whether to skip downloading gcloud (assumes gcloud is already available outside the module)"
+  type        = bool
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -202,3 +202,9 @@ variable "budget_alert_spent_percents" {
   type        = list(number)
   default     = [0.5, 0.7, 1.0]
 }
+
+variable "skip_gcloud_download" {
+  description = "Whether to skip downloading gcloud (assumes gcloud is already available outside the module)"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Adds ability to skip the downloading of the gcloud CLI. Exposing this functionality is important to us because:
- the download functionality adds a lot of unnecessary overhead when running in our ci pipeline which runs in a container image with gcloud pre-installed
- the resources it adds to the terraform plan make the plan harder to read
- it seems to scale not so well with the amount of projects because the gcloud cli is installed once for every module instance instead of once overall

Similar to https://github.com/terraform-google-modules/terraform-google-project-factory/pull/369. However, that PR semms to contain other unreleated changes