### PR TITLE
Bump version of terraform-google-gcloud module to 1.0.0

### DIFF
--- a/modules/core_project_factory/main.tf
+++ b/modules/core_project_factory/main.tf
@@ -158,7 +158,7 @@ data "null_data_source" "default_service_account" {
  *****************************************/
 module "gcloud_delete" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 0.5.0"
+  version = "~> 1.0.0"
 
   enabled                           = var.default_service_account == "delete"
   use_tf_google_credentials_env_var = var.use_tf_google_credentials_env_var
@@ -186,7 +186,7 @@ module "gcloud_delete" {
  ********************************************/
 module "gcloud_deprivilege" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 0.5.0"
+  version = "~> 1.0.0"
 
   enabled                           = var.default_service_account == "deprivilege"
   use_tf_google_credentials_env_var = var.use_tf_google_credentials_env_var
@@ -214,7 +214,7 @@ module "gcloud_deprivilege" {
  *****************************************/
 module "gcloud_disable" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 0.5.0"
+  version = "~> 1.0.0"
 
   enabled                           = var.default_service_account == "disable"
   use_tf_google_credentials_env_var = var.use_tf_google_credentials_env_var


### PR DESCRIPTION
This PR bumps the terraform-google-gcloud module to the newly release 1.0.0 version. I'm eager to try this out on our project. Big thanks to everyone involved!

Related issue: https://github.com/terraform-google-modules/terraform-google-project-factory/issues/396

Related issue on the terraform-google-gcloud https://github.com/terraform-google-modules/terraform-google-gcloud/issues/37