### PR TITLE
fix docs to correct skip_gcloud_download var

### DIFF
--- a/docs/upgrading_to_project_factory_v8.0.md
+++ b/docs/upgrading_to_project_factory_v8.0.md
@@ -6,4 +6,4 @@ The v8.0 release of Project Factory updates the `gcloud` module to use the [1.0.
 If you are relying on the built-in gcloud module, you will need to make sure `curl`
 is available in your Terraform execution environment.
 
-If you have `skip_download` set to `true`, no change is necessary.
+If you have `skip_gcloud_download` set to `true`, no change is necessary.


### PR DESCRIPTION
It will confuse users if we ask them to set a variable which doesn't exist. Note: `skip_download` is a variable of `terraform-google-modules/gcloud/google` not `terraform-google-modules/project-factory/google`.