### PR TITLE
feat: Enable GCS bucket versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ determining that location is as follows:
 | bucket\_location | The location for a GCS bucket to create (optional) | string | `"US"` | no |
 | bucket\_name | A name for a GCS bucket to create (in the bucket_project project), useful for Terraform state (optional) | string | `""` | no |
 | bucket\_project | A project to create a GCS bucket (bucket_name) in, useful for Terraform state (optional) | string | `""` | no |
+| bucket\_versioning | Enable versioning for a GCS bucket to create (optional) | bool | `"false"` | no |
 | budget\_alert\_pubsub\_topic | The name of the Cloud Pub/Sub topic where budget related messages will be published, in the form of `projects/{project_id}/topics/{topic_id}` | string | `"null"` | no |
 | budget\_alert\_spent\_percents | A list of percentages of the budget to alert on when threshold is exceeded | list(number) | `<list>` | no |
 | budget\_amount | The amount to use for a budget alert | number | `"null"` | no |

--- a/main.tf
+++ b/main.tf
@@ -51,6 +51,7 @@ module "project-factory" {
   bucket_project                    = var.bucket_project
   bucket_name                       = var.bucket_name
   bucket_location                   = var.bucket_location
+  bucket_versioning                 = var.bucket_versioning
   auto_create_network               = var.auto_create_network
   disable_services_on_destroy       = var.disable_services_on_destroy
   default_service_account           = var.default_service_account

--- a/modules/core_project_factory/main.tf
+++ b/modules/core_project_factory/main.tf
@@ -394,6 +394,10 @@ resource "google_storage_bucket" "project_bucket" {
   name     = local.project_bucket_name
   project  = var.bucket_project == local.base_project_id ? google_project.main.project_id : var.bucket_project
   location = var.bucket_location
+
+  versioning {
+    enabled = var.bucket_versioning
+  }
 }
 
 /***********************************************

--- a/modules/core_project_factory/variables.tf
+++ b/modules/core_project_factory/variables.tf
@@ -143,6 +143,12 @@ variable "bucket_location" {
   default     = "US"
 }
 
+variable "bucket_versioning" {
+  description = "Enable versioning for a GCS bucket to create (optional)"
+  type        = bool
+  default     = false
+}
+
 variable "auto_create_network" {
   description = "Create the default network"
   type        = bool

--- a/modules/gsuite_enabled/README.md
+++ b/modules/gsuite_enabled/README.md
@@ -65,6 +65,7 @@ The roles granted are specifically:
 | bucket\_location | The location for a GCS bucket to create (optional) | string | `""` | no |
 | bucket\_name | A name for a GCS bucket to create (in the bucket_project project), useful for Terraform state (optional) | string | `""` | no |
 | bucket\_project | A project to create a GCS bucket (bucket_name) in, useful for Terraform state (optional) | string | `""` | no |
+| bucket\_versioning | Enable versioning for a GCS bucket to create (optional) | bool | `"false"` | no |
 | budget\_alert\_pubsub\_topic | The name of the Cloud Pub/Sub topic where budget related messages will be published, in the form of `projects/{project_id}/topics/{topic_id}` | string | `"null"` | no |
 | budget\_alert\_spent\_percents | A list of percentages of the budget to alert on when threshold is exceeded | list(number) | `<list>` | no |
 | budget\_amount | The amount to use for a budget alert | number | `"null"` | no |

--- a/modules/gsuite_enabled/main.tf
+++ b/modules/gsuite_enabled/main.tf
@@ -93,6 +93,7 @@ module "project-factory" {
   bucket_project                    = var.bucket_project
   bucket_name                       = var.bucket_name
   bucket_location                   = var.bucket_location
+  bucket_versioning                 = var.bucket_versioning
   auto_create_network               = var.auto_create_network
   disable_services_on_destroy       = var.disable_services_on_destroy
   default_service_account           = var.default_service_account

--- a/modules/gsuite_enabled/variables.tf
+++ b/modules/gsuite_enabled/variables.tf
@@ -137,6 +137,12 @@ variable "bucket_location" {
   default     = ""
 }
 
+variable "bucket_versioning" {
+  description = "Enable versioning for a GCS bucket to create (optional)"
+  type        = bool
+  default     = false
+}
+
 variable "api_sa_group" {
   description = "A G Suite group to place the Google APIs Service Account for the project in"
   default     = ""

--- a/modules/shared_vpc/main.tf
+++ b/modules/shared_vpc/main.tf
@@ -44,6 +44,7 @@ module "project-factory" {
   activate_apis                     = var.activate_apis
   usage_bucket_name                 = var.usage_bucket_name
   usage_bucket_prefix               = var.usage_bucket_prefix
+  bucket_versioning                 = var.bucket_versioning
   credentials_path                  = var.credentials_path
   shared_vpc_subnets                = var.shared_vpc_subnets
   labels                            = var.labels

--- a/modules/shared_vpc/variables.tf
+++ b/modules/shared_vpc/variables.tf
@@ -129,6 +129,12 @@ variable "bucket_location" {
   default     = "US"
 }
 
+variable "bucket_versioning" {
+  description = "Enable versioning for a GCS bucket to create (optional)"
+  type        = bool
+  default     = false
+}
+
 variable "auto_create_network" {
   description = "Create the default network"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -137,6 +137,12 @@ variable "bucket_location" {
   default     = "US"
 }
 
+variable "bucket_versioning" {
+  description = "Enable versioning for a GCS bucket to create (optional)"
+  type        = bool
+  default     = false
+}
+
 variable "auto_create_network" {
   description = "Create the default network"
   type        = bool


### PR DESCRIPTION
Since GCS bucket created withing project creating is mostly used for Terraform state storing, enable versioning is highly recommended for it.
This PR provides `bucket_versioning` key to enable versioning, however disables versioning by default for compatibility.