### PR TITLE
fix: Add dependency on svpc

### DIFF
--- a/examples/shared_vpc/main.tf
+++ b/examples/shared_vpc/main.tf
@@ -147,3 +147,15 @@ module "service-project-b" {
 
   disable_services_on_destroy = "false"
 }
+
+/******************************************
+  Example dependency on service-project
+ *****************************************/
+
+resource "google_compute_address" "example_address" {
+  project      = module.service-project.project_id
+  region       = "us-west1"
+  subnetwork   = module.vpc.subnets_self_links[0]
+  name         = "test-address"
+  address_type = "INTERNAL"
+}

--- a/modules/core_project_factory/outputs.tf
+++ b/modules/core_project_factory/outputs.tf
@@ -23,6 +23,7 @@ output "project_id" {
     concat(
       [module.project_services.project_id],
       [google_project.main.project_id],
+      [var.shared_vpc_enabled ? google_compute_shared_vpc_service_project.shared_vpc_attachment[0].id : ""],
     ),
     0,
   )


### PR DESCRIPTION
Wait for `google_compute_shared_vpc_service_project` to resolve before output `project_id`