### PR TITLE
Creating shared_vpc_access submodule

### DIFF
--- a/docs/upgrading_to_project_factory_v9.0.md
+++ b/docs/upgrading_to_project_factory_v9.0.md
@@ -1,0 +1,105 @@
+# Upgrading to Project Factory v9.0
+
+The v9.0 release of Project Factory is a backwards incompatible release for
+service projects created with [shared_vpc](../modules/shared_vpc) module that
+also have `container.googleapis.com` and/or `dataproc.googleapis.com` API's
+enabled. If you don't have these API's enabled on your service projects or you
+are creating new projects then there is no action required on your end.
+
+## Migration Instructions
+
+If your service projects have the `container.googleapis.com` API enabled then
+follow instructions in [GKE API already enabled](#gke-api-already-enabled).
+
+If your service projects have the `dataproc.googleapis.com` API enabled then
+follow instructions in [Dataproc API already enabled](#dataproc-api-already-enabled).
+
+### GKE API already enabled
+
+If you have the `container.googleapis.com` API enabled you will see in your
+terraform plan that `google_compute_subnetwork_iam_member`
+and `google_compute_subnetwork_iam_member` resources will be recreated. This is
+a safe operation and you can apply the changes. Example plan can look like this:
+```diff
+# module.example.module.service-project.module.project-factory.google_compute_subnetwork_iam_member.gke_shared_vpc_subnets[0] will be destroyed
+  - resource "google_compute_subnetwork_iam_member" "gke_shared_vpc_subnets" {
+      - etag       = "BwWrwEtp6B4=" -> null
+      - id         = "projects/pf-ci-shared2-host-0004-29fd/regions/us-west1/subnetworks/shared-network-subnet-01/roles/compute.networkUser/serviceaccount:service-740499050292@container-engine-robot.iam.gserviceaccount.com" -> null
+      - member     = "serviceAccount:service-740499050292@container-engine-robot.iam.gserviceaccount.com" -> null
+      - project    = "pf-ci-shared2-host-0004-29fd" -> null
+      - region     = "us-west1" -> null
+      - role       = "roles/compute.networkUser" -> null
+      - subnetwork = "projects/pf-ci-shared2-host-0004-29fd/regions/us-west1/subnetworks/shared-network-subnet-01" -> null
+    }
+
+  # module.example.module.service-project.module.project-factory.google_compute_subnetwork_iam_member.gke_shared_vpc_subnets[1] will be destroyed
+  - resource "google_compute_subnetwork_iam_member" "gke_shared_vpc_subnets" {
+      - etag       = "BwWrwEtrwLA=" -> null
+      - id         = "projects/pf-ci-shared2-host-0004-29fd/regions/us-west1/subnetworks/shared-network-subnet-02/roles/compute.networkUser/serviceaccount:service-740499050292@container-engine-robot.iam.gserviceaccount.com" -> null
+      - member     = "serviceAccount:service-740499050292@container-engine-robot.iam.gserviceaccount.com" -> null
+      - project    = "pf-ci-shared2-host-0004-29fd" -> null
+      - region     = "us-west1" -> null
+      - role       = "roles/compute.networkUser" -> null
+      - subnetwork = "projects/pf-ci-shared2-host-0004-29fd/regions/us-west1/subnetworks/shared-network-subnet-02" -> null
+    }
+
+  # module.example.module.service-project.module.project-factory.google_project_iam_member.gke_host_agent[0] will be destroyed
+  - resource "google_project_iam_member" "gke_host_agent" {
+      - etag    = "BwWrwEtQfSY=" -> null
+      - id      = "pf-ci-shared2-host-0004-29fd/roles/container.hostServiceAgentUser/serviceaccount:service-740499050292@container-engine-robot.iam.gserviceaccount.com" -> null
+      - member  = "serviceAccount:service-740499050292@container-engine-robot.iam.gserviceaccount.com" -> null
+      - project = "pf-ci-shared2-host-0004-29fd" -> null
+      - role    = "roles/container.hostServiceAgentUser" -> null
+    }
+
+  # module.example.module.service-project.module.shared_vpc_access.google_compute_subnetwork_iam_member.gke_shared_vpc_subnets[0] will be created
+  + resource "google_compute_subnetwork_iam_member" "gke_shared_vpc_subnets" {
+      + etag       = (known after apply)
+      + id         = (known after apply)
+      + member     = "serviceAccount:service-740499050292@container-engine-robot.iam.gserviceaccount.com"
+      + project    = "pf-ci-shared2-host-0004-29fd"
+      + region     = "us-west1"
+      + role       = "roles/compute.networkUser"
+      + subnetwork = "shared-network-subnet-01"
+    }
+
+  # module.example.module.service-project.module.shared_vpc_access.google_compute_subnetwork_iam_member.gke_shared_vpc_subnets[1] will be created
+  + resource "google_compute_subnetwork_iam_member" "gke_shared_vpc_subnets" {
+      + etag       = (known after apply)
+      + id         = (known after apply)
+      + member     = "serviceAccount:service-740499050292@container-engine-robot.iam.gserviceaccount.com"
+      + project    = "pf-ci-shared2-host-0004-29fd"
+      + region     = "us-west1"
+      + role       = "roles/compute.networkUser"
+      + subnetwork = "shared-network-subnet-02"
+    }
+
+  # module.example.module.service-project.module.shared_vpc_access.google_project_iam_member.gke_host_agent[0] will be created
+  + resource "google_project_iam_member" "gke_host_agent" {
+      + etag    = (known after apply)
+      + id      = (known after apply)
+      + member  = "serviceAccount:service-740499050292@container-engine-robot.iam.gserviceaccount.com"
+      + project = "pf-ci-shared2-host-0004-29fd"
+      + role    = "roles/container.hostServiceAgentUser"
+    }
+```
+
+### Dataproc API already enabled
+If you have `dataproc.googleapis.com` API enabled on your projects then terraform
+plan will try to bind `roles/compute.networkUser` to
+`service-<PROJECT_NUMBER>@dataproc-accounts.iam.gserviceaccount.com` at the
+project level. Example:
+```diff
+  # module.example.module.service-project.module.shared_vpc_access.google_project_iam_member.dataproc_shared_vpc_network_user[0] will be created
+  + resource "google_project_iam_member" "dataproc_shared_vpc_network_user" {
+      + etag    = (known after apply)
+      + id      = (known after apply)
+      + member  = "serviceAccount:service-740499050292@dataproc-accounts.iam.gserviceaccount.com"
+      + project = "pf-ci-shared2-host-0004-29fd"
+      + role    = "roles/compute.networkUser"
+    }
+```
+
+If you have already binded the `roles/compute.networkUser` to
+`service-<PROJECT_NUMBER>@dataproc-accounts.iam.gserviceaccount.com` at the
+project level then please remove that binding before running `terraform apply`.

--- a/examples/shared_vpc/main.tf
+++ b/examples/shared_vpc/main.tf
@@ -42,12 +42,13 @@ provider "random" {
   Host Project Creation
  *****************************************/
 module "host-project" {
-  source            = "../../"
-  random_project_id = true
-  name              = var.host_project_name
-  org_id            = var.organization_id
-  folder_id         = var.folder_id
-  billing_account   = var.billing_account
+  source               = "../../"
+  random_project_id    = true
+  name                 = var.host_project_name
+  org_id               = var.organization_id
+  folder_id            = var.folder_id
+  billing_account      = var.billing_account
+  skip_gcloud_download = true
 }
 
 /******************************************
@@ -119,9 +120,11 @@ module "service-project" {
   activate_apis = [
     "compute.googleapis.com",
     "container.googleapis.com",
+    "dataproc.googleapis.com",
   ]
 
   disable_services_on_destroy = "false"
+  skip_gcloud_download        = "true"
 }
 
 /******************************************
@@ -143,9 +146,11 @@ module "service-project-b" {
   activate_apis = [
     "compute.googleapis.com",
     "container.googleapis.com",
+    "dataproc.googleapis.com",
   ]
 
   disable_services_on_destroy = "false"
+  skip_gcloud_download        = "true"
 }
 
 /******************************************

--- a/modules/core_project_factory/outputs.tf
+++ b/modules/core_project_factory/outputs.tf
@@ -84,3 +84,8 @@ output "api_s_account_fmt" {
   value       = local.api_s_account_fmt
   description = "API service account email formatted for terraform use"
 }
+
+output "enabled_apis" {
+  description = "Enabled APIs in the project"
+  value       = module.project_services.enabled_apis
+}

--- a/modules/project_services/README.md
+++ b/modules/project_services/README.md
@@ -49,6 +49,7 @@ See [examples/project_services](./examples/project_services) for a full example 
 
 | Name | Description |
 |------|-------------|
+| enabled\_apis | Enabled APIs in the project |
 | project\_id | The GCP project you want to enable APIs on |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/shared_vpc/main.tf
+++ b/modules/shared_vpc/main.tf
@@ -61,6 +61,17 @@ module "project-factory" {
 }
 
 /******************************************
+  Setting API service accounts for shared VPC
+ *****************************************/
+module "shared_vpc_access" {
+  source             = "../shared_vpc_access"
+  host_project_id    = var.shared_vpc
+  service_project_id = module.project-factory.project_id
+  active_apis        = module.project-factory.enabled_apis
+  shared_vpc_subnets = var.shared_vpc_subnets
+}
+
+/******************************************
   Billing budget to create if amount is set
  *****************************************/
 module "budget" {

--- a/modules/shared_vpc/outputs.tf
+++ b/modules/shared_vpc/outputs.tf
@@ -21,7 +21,7 @@ output "project_name" {
 
 output "project_id" {
   description = "If provided, the project uses the given project ID. Mutually exclusive with random_project_id being true."
-  value       = module.project-factory.project_id
+  value       = module.shared_vpc_access.project_id
 }
 
 output "project_number" {

--- a/modules/shared_vpc_access/README.md
+++ b/modules/shared_vpc_access/README.md
@@ -1,0 +1,41 @@
+# Shared VPC Access
+
+This module grants IAM permissions on host project and subnets to appropriate API service accounts based on activated
+APIs. For now only GKE and Dataproc APIs are supported.
+
+## Example Usage
+```hcl
+module "shared_vpc_access" {
+  source              = "terraform-google-modules/project-factory/google//modules/shared_vpc_access"
+  host_project_id     = var.shared_vpc
+  service_project_id  = var.service_project
+  active_apis         = [
+    "compute.googleapis.com",
+    "container.googleapis.com",
+    "dataproc.googleapis.com",
+  ]
+  shared_vpc_subnets  = [
+    "projects/pf-ci-shared2/regions/us-west1/subnetworks/shared-network-subnet-01",
+    "projects/pf-ci-shared2/regions/us-west1/subnetworks/shared-network-subnet-02",
+  ]
+}
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| active\_apis | The list of active apis on the service project. If api is not active this module will not try to activate it | list(string) | `<list>` | no |
+| host\_project\_id | The ID of the host project which hosts the shared VPC | string | n/a | yes |
+| service\_project\_id | The ID of the service project | string | n/a | yes |
+| shared\_vpc\_subnets | List of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id) | list(string) | `<list>` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| active\_api\_service\_accounts | List of active API service accounts in the service project. |
+| project\_id | Service project ID. |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/shared_vpc_access/main.tf
+++ b/modules/shared_vpc_access/main.tf
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+data "google_project" "service_project" {
+  project_id = var.service_project_id
+}
+
+locals {
+  gke_shared_vpc_enabled = contains(var.active_apis, "container.googleapis.com")
+  gke_s_account = local.gke_shared_vpc_enabled ? format(
+    "service-%s@container-engine-robot.iam.gserviceaccount.com",
+    data.google_project.service_project.number,
+  ) : ""
+  dataproc_shared_vpc_enabled = contains(var.active_apis, "dataproc.googleapis.com")
+  dataproc_s_account = local.dataproc_shared_vpc_enabled ? format(
+    "service-%s@dataproc-accounts.iam.gserviceaccount.com",
+    data.google_project.service_project.number
+  ) : ""
+  active_api_s_accounts = compact([local.gke_s_account, local.dataproc_s_account])
+}
+
+/******************************************
+  compute.networkUser role granted to GKE service account for GKE on shared VPC subnets
+  See: https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc
+ *****************************************/
+resource "google_compute_subnetwork_iam_member" "gke_shared_vpc_subnets" {
+  provider = google-beta
+  count    = local.gke_shared_vpc_enabled && length(var.shared_vpc_subnets) != 0 ? length(var.shared_vpc_subnets) : 0
+  subnetwork = element(
+    split("/", var.shared_vpc_subnets[count.index]),
+    index(
+      split("/", var.shared_vpc_subnets[count.index]),
+      "subnetworks",
+    ) + 1,
+  )
+  role = "roles/compute.networkUser"
+  region = element(
+    split("/", var.shared_vpc_subnets[count.index]),
+    index(split("/", var.shared_vpc_subnets[count.index]), "regions") + 1,
+  )
+  project = var.host_project_id
+  member  = format("serviceAccount:%s", local.gke_s_account)
+}
+
+/******************************************
+  container.hostServiceAgentUser role granted to GKE service account for GKE on shared VPC
+  See:https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc
+ *****************************************/
+resource "google_project_iam_member" "gke_host_agent" {
+  count   = local.gke_shared_vpc_enabled ? 1 : 0
+  project = var.host_project_id
+  role    = "roles/container.hostServiceAgentUser"
+  member  = format("serviceAccount:%s", local.gke_s_account)
+}
+
+/******************************************
+  compute.networkUser role granted to dataproc service account for dataproc on shared VPC subnets
+  See: https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/network#creating_a_cluster_that_uses_a_vpc_network_in_another_project
+ *****************************************/
+resource "google_project_iam_member" "dataproc_shared_vpc_network_user" {
+  count   = local.dataproc_shared_vpc_enabled ? 1 : 0
+  project = var.host_project_id
+  role    = "roles/compute.networkUser"
+  member  = format("serviceAccount:%s", local.dataproc_s_account)
+}

--- a/modules/shared_vpc_access/outputs.tf
+++ b/modules/shared_vpc_access/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,17 @@
  * limitations under the License.
  */
 
-output "project_id" {
-  description = "The GCP project you want to enable APIs on"
-  value       = element(concat([for v in google_project_service.project_services : v.project], [var.project_id]), 0)
+output "active_api_service_accounts" {
+  description = "List of active API service accounts in the service project."
+  value       = local.active_api_s_accounts
 }
 
-output "enabled_apis" {
-  description = "Enabled APIs in the project"
-  value       = [for api in google_project_service.project_services : api.service]
+output "project_id" {
+  description = "Service project ID."
+  value       = var.service_project_id
+  depends_on = [
+    google_compute_subnetwork_iam_member.gke_shared_vpc_subnets,
+    google_project_iam_member.gke_host_agent,
+    google_project_iam_member.dataproc_shared_vpc_network_user,
+  ]
 }

--- a/modules/shared_vpc_access/variables.tf
+++ b/modules/shared_vpc_access/variables.tf
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "host_project_id" {
+  description = "The ID of the host project which hosts the shared VPC"
+  type        = string
+}
+
+variable "service_project_id" {
+  description = "The ID of the service project"
+  type        = string
+}
+
+variable "shared_vpc_subnets" {
+  description = "List of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id)"
+  type        = list(string)
+  default     = []
+}
+
+variable "active_apis" {
+  description = "The list of active apis on the service project. If api is not active this module will not try to activate it"
+  type        = list(string)
+  default     = []
+}

--- a/modules/shared_vpc_access/versions.tf
+++ b/modules/shared_vpc_access/versions.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-output "project_id" {
-  description = "The GCP project you want to enable APIs on"
-  value       = element(concat([for v in google_project_service.project_services : v.project], [var.project_id]), 0)
-}
+terraform {
+  required_version = "~> 0.12.6"
 
-output "enabled_apis" {
-  description = "Enabled APIs in the project"
-  value       = [for api in google_project_service.project_services : api.service]
+  required_providers {
+    google      = ">= 3.8, < 4.0"
+    google-beta = ">= 3.8, < 4.0"
+  }
 }

--- a/test/integration/dynamic_shared_vpc/controls/svpc.rb
+++ b/test/integration/dynamic_shared_vpc/controls/svpc.rb
@@ -69,6 +69,13 @@ control 'svpc' do
         role: "roles/container.hostServiceAgentUser",
       )
     end
+
+    it "includes the dataproc service account in the roles/compute.networkUser IAM binding" do
+      expect(bindings).to include(
+        members: including("serviceAccount:service-#{service_project_number}@dataproc-accounts.iam.gserviceaccount.com"),
+        role: "roles/compute.networkUser",
+      )
+    end
   end
 
   describe command("gcloud beta compute networks subnets get-iam-policy #{shared_vpc_subnet_name_01} --region #{shared_vpc_subnet_region_01} --project #{shared_vpc} --format=json") do


### PR DESCRIPTION
This submodule is used to control access of the API service accounts
on the host project. Service Accounts are given appropriate permissions
based on the list of active apis. The module is meant to be extended in
the future with more support for API service accounts.

Note: I have set `skip_gcloud_download  = "true"` in `examples/shared_vpc/main.tf` 
to speed up integration testing.