### PR TITLE
Adding ability to tie subnets to API's

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ determining that location is as follows:
 | random\_project\_id | Adds a suffix of 4 random characters to the `project_id` | bool | `"false"` | no |
 | sa\_role | A role to give the default Service Account for the project (defaults to none) | string | `""` | no |
 | shared\_vpc | The ID of the host project which hosts the shared VPC | string | `""` | no |
-| shared\_vpc\_subnets | List of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id) | list(string) | `<list>` | no |
+| shared\_vpc\_subnets | Map of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id) and list of allowed API's. Example: projects/$project_id/regions/$region/subnetworks/$subnet_id = [] or projects/$project_id/regions/$region/subnetworks/$subnet_id = ["gke"]. Valid values for API list are: "", "gke", and "dataproc" | map(list(string)) | `<map>` | no |
 | skip\_gcloud\_download | Whether to skip downloading gcloud (assumes gcloud is already available outside the module) | bool | `"false"` | no |
 | usage\_bucket\_name | Name of a GCS bucket to store GCE usage reports in (optional) | string | `""` | no |
 | usage\_bucket\_prefix | Prefix in the GCS bucket to store GCE usage reports in (optional) | string | `""` | no |

--- a/docs/upgrading_to_project_factory_v10.0.md
+++ b/docs/upgrading_to_project_factory_v10.0.md
@@ -1,0 +1,58 @@
+# Upgrading to Project Factory v10.0
+
+The v10.0 release of Project Factory is a backwards incompatible release for
+service projects that have `shared_vpc_subnets` set. The variable type of
+`shared_vpc_subnets` has changed from `list(string)` to `map(list(string))`.
+In the previous versions all subnets listed in `shared_vpc_subnets` would be
+set with GKE or Dataproc permissions if these API's are enabled. Starting from
+version 10.0 you can specify which subnets are set for gke or dataproc.
+
+## Migration Instructions
+
+If you have `shared_vpc_subnets` set in your module you will have to change it
+to be a map
+```diff
+ diff --git a/examples/shared_vpc/main.tf b/examples/shared_vpc/main.tf
+index eb31a6b..95a85fd 100644
+--- a/examples/shared_vpc/main.tf
++++ b/examples/shared_vpc/main.tf
+@@ -114,8 +114,11 @@ module "service-project" {
+   billing_account    = var.billing_account
+   shared_vpc_enabled = true
+
+-  shared_vpc         = module.vpc.project_id
+-  shared_vpc_subnets = module.vpc.subnets_self_links
++  shared_vpc = module.vpc.project_id
++  shared_vpc_subnets = {
++    "${module.vpc.subnets_self_links[0]}" = ["gke"]
++    "${module.vpc.subnets_self_links[1]}" = ["dataproc"]
++    "${module.vpc.subnets_self_links[1]}" = []
++  }
+```
+
+Once you run `teraform plan` you will notices change in IAM permissions for
+sunets. It can look something like this:
+```
+  # module.example.module.service-project.module.shared_vpc_access.google_compute_subnetwork_iam_member.dataproc_shared_vpc_subnets[0] will be created
+  + resource "google_compute_subnetwork_iam_member" "dataproc_shared_vpc_subnets" {
+      + etag       = (known after apply)
+      + id         = (known after apply)
+      + member     = "serviceAccount:service-740499050292@dataproc-accounts.iam.gserviceaccount.com"
+      + project    = "pf-ci-shared2-host-0004-29fd"
+      + region     = "us-west1"
+      + role       = "roles/compute.networkUser"
+      + subnetwork = "shared-network-subnet-02"
+    }
+
+  # module.example.module.service-project.module.shared_vpc_access.google_compute_subnetwork_iam_member.gke_shared_vpc_subnets[1] will be destroyed
+  - resource "google_compute_subnetwork_iam_member" "gke_shared_vpc_subnets" {
+      - etag       = "BwWrwRqi1lc=" -> null
+      - id         = "projects/pf-ci-shared2-host-0004-29fd/regions/us-west1/subnetworks/shared-network-subnet-02/roles/compute.networkUser/serviceaccount:service-740499050292@container-engine-robot.iam.gserviceaccount.com" -> null
+      - member     = "serviceAccount:service-740499050292@container-engine-robot.iam.gserviceaccount.com" -> null
+      - project    = "pf-ci-shared2-host-0004-29fd" -> null
+      - region     = "us-west1" -> null
+      - role       = "roles/compute.networkUser" -> null
+      - subnetwork = "projects/pf-ci-shared2-host-0004-29fd/regions/us-west1/subnetworks/shared-network-subnet-02" -> null
+    }
+```
+In this case it is safe to run `terraform apply`.

--- a/examples/gke_shared_vpc/README.md
+++ b/examples/gke_shared_vpc/README.md
@@ -32,6 +32,6 @@ More information about GKE with Shared VPC can be found here: https://cloud.goog
 | credentials\_path | Path to a Service Account credentials file with permissions documented in the readme | string | n/a | yes |
 | org\_id | organization id | string | n/a | yes |
 | shared\_vpc | The ID of the host project which hosts the shared VPC | string | n/a | yes |
-| shared\_vpc\_subnets | List of subnets fully qualified subnet IDs (ie. projects/$PROJECT_ID/regions/$REGION/subnetworks/$SUBNET_ID) | list(string) | `<list>` | no |
+| shared\_vpc\_subnets | Map of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id) and list of allowed API's. Example: projects/$project_id/regions/$region/subnetworks/$subnet_id = [] or projects/$project_id/regions/$region/subnetworks/$subnet_id = ["gke"]. Valid values for API list are: "", "gke", and "dataproc" | map(list(string)) | `<map>` | no |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/gke_shared_vpc/variables.tf
+++ b/examples/gke_shared_vpc/variables.tf
@@ -31,8 +31,8 @@ variable "shared_vpc" {
 }
 
 variable "shared_vpc_subnets" {
-  description = "List of subnets fully qualified subnet IDs (ie. projects/$PROJECT_ID/regions/$REGION/subnetworks/$SUBNET_ID)"
-  type        = list(string)
-  default     = []
+  description = "Map of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id) and list of allowed API's. Example: projects/$project_id/regions/$region/subnetworks/$subnet_id = [] or projects/$project_id/regions/$region/subnetworks/$subnet_id = [\"gke\"]. Valid values for API list are: \"\", \"gke\", and \"dataproc\""
+  type        = map(list(string))
+  default     = {}
 }
 

--- a/examples/shared_vpc/main.tf
+++ b/examples/shared_vpc/main.tf
@@ -114,8 +114,11 @@ module "service-project" {
   billing_account    = var.billing_account
   shared_vpc_enabled = true
 
-  shared_vpc         = module.vpc.project_id
-  shared_vpc_subnets = module.vpc.subnets_self_links
+  shared_vpc = module.vpc.project_id
+  shared_vpc_subnets = {
+    "${module.vpc.subnets_self_links[0]}" = ["gke"]
+    "${module.vpc.subnets_self_links[1]}" = ["dataproc"]
+  }
 
   activate_apis = [
     "compute.googleapis.com",

--- a/modules/core_project_factory/main.tf
+++ b/modules/core_project_factory/main.tf
@@ -46,7 +46,7 @@ locals {
   api_s_account_fmt   = format("serviceAccount:%s", local.api_s_account)
   project_bucket_name = var.bucket_name != "" ? var.bucket_name : format("%s-state", local.temp_project_id)
   create_bucket       = var.bucket_project != "" ? "true" : "false"
-
+  shared_vpc_subnets  = distinct(keys(var.shared_vpc_subnets))
   shared_vpc_users = compact(
     [
       local.group_id,
@@ -278,7 +278,7 @@ resource "google_service_account_iam_member" "service_account_grant_to_group" {
   compute.networkUser role granted to G Suite group, APIs Service account, and Project Service Account
  *****************************************************************************************************************/
 resource "google_project_iam_member" "controlling_group_vpc_membership" {
-  count = var.shared_vpc_enabled && length(var.shared_vpc_subnets) == 0 ? local.shared_vpc_users_length : 0
+  count = var.shared_vpc_enabled && length(local.shared_vpc_subnets) == 0 ? local.shared_vpc_users_length : 0
 
   project = var.shared_vpc
   role    = "roles/compute.networkUser"
@@ -294,19 +294,19 @@ resource "google_project_iam_member" "controlling_group_vpc_membership" {
  *************************************************************************************/
 resource "google_compute_subnetwork_iam_member" "service_account_role_to_vpc_subnets" {
   provider = google-beta
-  count    = var.shared_vpc_enabled && length(var.shared_vpc_subnets) > 0 ? length(var.shared_vpc_subnets) : 0
+  count    = var.shared_vpc_enabled && length(local.shared_vpc_subnets) > 0 ? length(local.shared_vpc_subnets) : 0
 
   subnetwork = element(
-    split("/", var.shared_vpc_subnets[count.index]),
+    split("/", local.shared_vpc_subnets[count.index]),
     index(
-      split("/", var.shared_vpc_subnets[count.index]),
+      split("/", local.shared_vpc_subnets[count.index]),
       "subnetworks",
     ) + 1,
   )
   role = "roles/compute.networkUser"
   region = element(
-    split("/", var.shared_vpc_subnets[count.index]),
-    index(split("/", var.shared_vpc_subnets[count.index]), "regions") + 1,
+    split("/", local.shared_vpc_subnets[count.index]),
+    index(split("/", local.shared_vpc_subnets[count.index]), "regions") + 1,
   )
   project = var.shared_vpc
   member  = local.s_account_fmt
@@ -318,18 +318,18 @@ resource "google_compute_subnetwork_iam_member" "service_account_role_to_vpc_sub
 resource "google_compute_subnetwork_iam_member" "group_role_to_vpc_subnets" {
   provider = google-beta
 
-  count = var.shared_vpc_enabled && length(var.shared_vpc_subnets) > 0 && var.manage_group ? length(var.shared_vpc_subnets) : 0
+  count = var.shared_vpc_enabled && length(local.shared_vpc_subnets) > 0 && var.manage_group ? length(local.shared_vpc_subnets) : 0
   subnetwork = element(
-    split("/", var.shared_vpc_subnets[count.index]),
+    split("/", local.shared_vpc_subnets[count.index]),
     index(
-      split("/", var.shared_vpc_subnets[count.index]),
+      split("/", local.shared_vpc_subnets[count.index]),
       "subnetworks",
     ) + 1,
   )
   role = "roles/compute.networkUser"
   region = element(
-    split("/", var.shared_vpc_subnets[count.index]),
-    index(split("/", var.shared_vpc_subnets[count.index]), "regions") + 1,
+    split("/", local.shared_vpc_subnets[count.index]),
+    index(split("/", local.shared_vpc_subnets[count.index]), "regions") + 1,
   )
   member  = local.group_id
   project = var.shared_vpc
@@ -341,18 +341,18 @@ resource "google_compute_subnetwork_iam_member" "group_role_to_vpc_subnets" {
 resource "google_compute_subnetwork_iam_member" "apis_service_account_role_to_vpc_subnets" {
   provider = google-beta
 
-  count = var.shared_vpc_enabled && length(var.shared_vpc_subnets) > 0 ? length(var.shared_vpc_subnets) : 0
+  count = var.shared_vpc_enabled && length(local.shared_vpc_subnets) > 0 ? length(local.shared_vpc_subnets) : 0
   subnetwork = element(
-    split("/", var.shared_vpc_subnets[count.index]),
+    split("/", local.shared_vpc_subnets[count.index]),
     index(
-      split("/", var.shared_vpc_subnets[count.index]),
+      split("/", local.shared_vpc_subnets[count.index]),
       "subnetworks",
     ) + 1,
   )
   role = "roles/compute.networkUser"
   region = element(
-    split("/", var.shared_vpc_subnets[count.index]),
-    index(split("/", var.shared_vpc_subnets[count.index]), "regions") + 1,
+    split("/", local.shared_vpc_subnets[count.index]),
+    index(split("/", local.shared_vpc_subnets[count.index]), "regions") + 1,
   )
   project = var.shared_vpc
   member  = local.api_s_account_fmt

--- a/modules/core_project_factory/variables.tf
+++ b/modules/core_project_factory/variables.tf
@@ -114,9 +114,9 @@ variable "impersonate_service_account" {
 }
 
 variable "shared_vpc_subnets" {
-  description = "List of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id)"
-  type        = list(string)
-  default     = []
+  description = "Map of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id) and list of allowed API's. Example: projects/$project_id/regions/$region/subnetworks/$subnet_id = [] or projects/$project_id/regions/$region/subnetworks/$subnet_id = [\"gke\"]. Valid values for API list are: \"\", \"gke\", and \"dataproc\""
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "labels" {

--- a/modules/gsuite_enabled/README.md
+++ b/modules/gsuite_enabled/README.md
@@ -90,7 +90,7 @@ The roles granted are specifically:
 | sa\_role | A role to give the default Service Account for the project (defaults to none) | string | `""` | no |
 | shared\_vpc | The ID of the host project which hosts the shared VPC | string | `""` | no |
 | shared\_vpc\_enabled | If shared VPC should be used | bool | `"false"` | no |
-| shared\_vpc\_subnets | List of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id) | list(string) | `<list>` | no |
+| shared\_vpc\_subnets | Map of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id) and list of allowed API's. Example: projects/$project_id/regions/$region/subnetworks/$subnet_id = [] or projects/$project_id/regions/$region/subnetworks/$subnet_id = ["gke"]. Valid values for API list are: "", "gke", and "dataproc" | map(list(string)) | `<map>` | no |
 | skip\_gcloud\_download | Whether to skip downloading gcloud (assumes gcloud is already available outside the module) | bool | `"false"` | no |
 | usage\_bucket\_name | Name of a GCS bucket to store GCE usage reports in (optional) | string | `""` | no |
 | usage\_bucket\_prefix | Prefix in the GCS bucket to store GCE usage reports in (optional) | string | `""` | no |

--- a/modules/gsuite_enabled/variables.tf
+++ b/modules/gsuite_enabled/variables.tf
@@ -111,9 +111,9 @@ variable "impersonate_service_account" {
 }
 
 variable "shared_vpc_subnets" {
-  description = "List of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id)"
-  type        = list(string)
-  default     = []
+  description = "Map of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id) and list of allowed API's. Example: projects/$project_id/regions/$region/subnetworks/$subnet_id = [] or projects/$project_id/regions/$region/subnetworks/$subnet_id = [\"gke\"]. Valid values for API list are: \"\", \"gke\", and \"dataproc\""
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "labels" {

--- a/modules/shared_vpc/variables.tf
+++ b/modules/shared_vpc/variables.tf
@@ -100,9 +100,9 @@ variable "credentials_path" {
 }
 
 variable "shared_vpc_subnets" {
-  description = "List of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id)"
-  type        = list(string)
-  default     = []
+  description = "Map of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id) and list of allowed API's. Example: projects/$project_id/regions/$region/subnetworks/$subnet_id = [] or projects/$project_id/regions/$region/subnetworks/$subnet_id = [\"gke\"]. Valid values for API list are: \"\", \"gke\", and \"dataproc\""
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "labels" {

--- a/modules/shared_vpc_access/README.md
+++ b/modules/shared_vpc_access/README.md
@@ -29,7 +29,7 @@ module "shared_vpc_access" {
 | active\_apis | The list of active apis on the service project. If api is not active this module will not try to activate it | list(string) | `<list>` | no |
 | host\_project\_id | The ID of the host project which hosts the shared VPC | string | n/a | yes |
 | service\_project\_id | The ID of the service project | string | n/a | yes |
-| shared\_vpc\_subnets | List of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id) | list(string) | `<list>` | no |
+| shared\_vpc\_subnets | Map of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id) and list of allowed API's. Example: projects/$project_id/regions/$region/subnetworks/$subnet_id = [] or projects/$project_id/regions/$region/subnetworks/$subnet_id = ["gke"]. Valid values for API list are: "", "gke", and "dataproc" | map(list(string)) | `<map>` | no |
 
 ## Outputs
 

--- a/modules/shared_vpc_access/variables.tf
+++ b/modules/shared_vpc_access/variables.tf
@@ -25,9 +25,9 @@ variable "service_project_id" {
 }
 
 variable "shared_vpc_subnets" {
-  description = "List of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id)"
-  type        = list(string)
-  default     = []
+  description = "Map of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id) and list of allowed API's. Example: projects/$project_id/regions/$region/subnetworks/$subnet_id = [] or projects/$project_id/regions/$region/subnetworks/$subnet_id = [\"gke\"]. Valid values for API list are: \"\", \"gke\", and \"dataproc\""
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "active_apis" {

--- a/test/fixtures/full/main.tf
+++ b/test/fixtures/full/main.tf
@@ -50,10 +50,12 @@ locals {
   shared_vpc_subnet_name_02   = module.vpc.subnets_names[1]
   shared_vpc_subnet_region_02 = module.vpc.subnets_regions[1]
 
-  shared_vpc_subnets = [
-    "projects/${var.shared_vpc}/regions/${local.shared_vpc_subnet_region_01}/subnetworks/${local.shared_vpc_subnet_name_01}",
-    "https://www.googleapis.com/compute/v1/projects/${var.shared_vpc}/regions/${local.shared_vpc_subnet_region_02}/subnetworks/${local.shared_vpc_subnet_name_02}",
-  ]
+  shared_vpc_subnets = {
+    "projects/${var.shared_vpc}/regions/${local.shared_vpc_subnet_region_01}/subnetworks/${local.shared_vpc_subnet_name_01}" = [
+      "gke"
+    ],
+    "https://www.googleapis.com/compute/v1/projects/${var.shared_vpc}/regions/${local.shared_vpc_subnet_region_02}/subnetworks/${local.shared_vpc_subnet_name_02}" = ["gke"],
+  }
 }
 
 module "vpc" {

--- a/variables.tf
+++ b/variables.tf
@@ -108,9 +108,9 @@ variable "impersonate_service_account" {
 }
 
 variable "shared_vpc_subnets" {
-  description = "List of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id)"
-  type        = list(string)
-  default     = []
+  description = "Map of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id) and list of allowed API's. Example: projects/$project_id/regions/$region/subnetworks/$subnet_id = [] or projects/$project_id/regions/$region/subnetworks/$subnet_id = [\"gke\"]. Valid values for API list are: \"\", \"gke\", and \"dataproc\""
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "labels" {


### PR DESCRIPTION
This commit enables users to specify if certain subnets are tied
to certains APIs. For example, now we can specify that a subnet is
a GKE subnet so that the roles/compute.networkUser will be granted
to GKE API service account on the subnet level.