### PR TITLE
chore: relax tf version to allow 0.13

### DIFF
--- a/examples/app_engine/versions.tf
+++ b/examples/app_engine/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/budget_project/versions.tf
+++ b/examples/budget_project/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/fabric_project/versions.tf
+++ b/examples/fabric_project/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/gke_shared_vpc/versions.tf
+++ b/examples/gke_shared_vpc/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/group_project/versions.tf
+++ b/examples/group_project/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/project-hierarchy/versions.tf
+++ b/examples/project-hierarchy/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/project_services/versions.tf
+++ b/examples/project_services/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/shared_vpc/versions.tf
+++ b/examples/shared_vpc/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/simple_project/versions.tf
+++ b/examples/simple_project/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/modules/app_engine/versions.tf
+++ b/modules/app_engine/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 
   required_providers {
     google = ">= 2.1, < 4.0"

--- a/modules/budget/versions.tf
+++ b/modules/budget/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 
   required_providers {
     google-beta = ">= 3.1, < 4.0"

--- a/modules/core_project_factory/versions.tf
+++ b/modules/core_project_factory/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 
   required_providers {
     google      = ">= 3.8, < 4.0"

--- a/modules/fabric-project/versions.tf
+++ b/modules/fabric-project/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 
   required_providers {
     google = ">= 3.1, < 4.0"

--- a/modules/gsuite_enabled/versions.tf
+++ b/modules/gsuite_enabled/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 
   required_providers {
     gsuite = "~> 0.1"

--- a/modules/gsuite_group/versions.tf
+++ b/modules/gsuite_group/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 
   required_providers {
     google = ">= 2.1, < 4.0"

--- a/modules/project_services/versions.tf
+++ b/modules/project_services/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 
   required_providers {
     google = ">= 2.1, < 4.0"

--- a/modules/shared_vpc/versions.tf
+++ b/modules/shared_vpc/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/modules/shared_vpc_access/versions.tf
+++ b/modules/shared_vpc_access/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 
   required_providers {
     google      = ">= 3.8, < 4.0"

--- a/test/fixtures/fabric_project/versions.tf
+++ b/test/fixtures/fabric_project/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/full/versions.tf
+++ b/test/fixtures/full/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/minimal/versions.tf
+++ b/test/fixtures/minimal/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/shared_vpc_no_subnets/versions.tf
+++ b/test/fixtures/shared_vpc_no_subnets/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/vpc_sc_project/versions.tf
+++ b/test/fixtures/vpc_sc_project/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }


### PR DESCRIPTION
- relax version constraint to allow usage with 0.13
- Kitchen tests [run with `v0.13.0-rc1`](https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/commit/88017ad3bc0d40473ac3d94546660328aeee878d) 
   - `minimal-local`, `fabric-project-local`, `app-engine-local`, `budget-local` passed
   - `vpc-sc-project-local`, `dynamic_shared_vpc` failed due to dependencies on other modules with version constraints
- module `for_each` and `depends_on` spot checked and seems to be working without issues