### PR TITLE
[DRAFT] chore: parallel builds for int tests

### DIFF
--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -22,7 +22,6 @@ steps:
   - 'TF_VAR_billing_account=$_BILLING_ACCOUNT'
   - 'TF_VAR_gsuite_admin_email=project-factory-test-admin@test.infra.cft.tips'
   - 'TF_VAR_gsuite_domain=test.infra.cft.tips'
-  - 'TF_VAR_org_id=$_ORG_ID'
   - 'TF_VAR_domain=test.infra.cft.tips.'
 - id: create minimal-local
   waitFor:

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -162,4 +162,3 @@ substitutions:
   _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.0'
 options:
   machineType: 'N1_HIGHCPU_8'
-  

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -138,6 +138,9 @@ steps:
       - create vpc-sc-project-local
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && export TF_VAR_policy_id=$(gcloud access-context-manager policies list --organization="${TF_VAR_org_id:?}" --format="value(name)") && kitchen_do converge vpc-sc-project-local']
+  env:
+  - 'TF_VAR_org_id=$_ORG_ID'
+  - 'TF_VAR_domain=test.infra.cft.tips.'
 - id: verify vpc-sc-project-local
   waitFor:
       - converge vpc-sc-project-local
@@ -148,6 +151,9 @@ steps:
     - verify vpc-sc-project-local
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && export TF_VAR_policy_id=$(gcloud access-context-manager policies list --organization="${TF_VAR_org_id:?}" --format="value(name)") && kitchen_do destroy vpc-sc-project-local']
+  env:
+  - 'TF_VAR_org_id=$_ORG_ID'
+  - 'TF_VAR_domain=test.infra.cft.tips.'
 tags:
 - 'ci'
 - 'integration'

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -16,14 +16,6 @@ steps:
 - id: prepare
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'mkdir -p ~/.terraform.d && ln -s /root/.terraform.d/plugins ~/.terraform.d/plugins && source /usr/local/bin/task_helper_functions.sh && prepare_environment']
-  env:
-  - 'TF_VAR_org_id=$_ORG_ID'
-  - 'TF_VAR_folder_id=$_FOLDER_ID'
-  - 'TF_VAR_billing_account=$_BILLING_ACCOUNT'
-  - 'TF_VAR_gsuite_admin_email=project-factory-test-admin@test.infra.cft.tips'
-  - 'TF_VAR_gsuite_domain=test.infra.cft.tips'
-  - 'TF_VAR_domain=test.infra.cft.tips.'
-  - 'GCLOUD_TF_DOWNLOAD=always'
 - id: create minimal-local
   waitFor:
       - prepare
@@ -143,9 +135,6 @@ steps:
       - create vpc-sc-project-local
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && export TF_VAR_policy_id=$(gcloud access-context-manager policies list --organization="${TF_VAR_org_id:?}" --format="value(name)") && kitchen_do converge vpc-sc-project-local']
-  env:
-  - 'TF_VAR_org_id=$_ORG_ID'
-  - 'TF_VAR_domain=test.infra.cft.tips.'
 - id: verify vpc-sc-project-local
   waitFor:
       - converge vpc-sc-project-local
@@ -156,9 +145,6 @@ steps:
     - verify vpc-sc-project-local
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && export TF_VAR_policy_id=$(gcloud access-context-manager policies list --organization="${TF_VAR_org_id:?}" --format="value(name)") && kitchen_do destroy vpc-sc-project-local']
-  env:
-  - 'TF_VAR_org_id=$_ORG_ID'
-  - 'TF_VAR_domain=test.infra.cft.tips.'
 tags:
 - 'ci'
 - 'integration'
@@ -167,3 +153,11 @@ substitutions:
   _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.0'
 options:
   machineType: 'N1_HIGHCPU_8'
+  env:
+    - 'TF_VAR_org_id=$_ORG_ID'
+    - 'TF_VAR_folder_id=$_FOLDER_ID'
+    - 'TF_VAR_billing_account=$_BILLING_ACCOUNT'
+    - 'TF_VAR_gsuite_admin_email=project-factory-test-admin@test.infra.cft.tips'
+    - 'TF_VAR_gsuite_domain=test.infra.cft.tips'
+    - 'TF_VAR_domain=test.infra.cft.tips.'
+    - 'GCLOUD_TF_DOWNLOAD=always'

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -27,7 +27,7 @@ steps:
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge minimal-local']
   env:
-  - 'GCLOUD_TF_DOWNLOAD=never'
+  - 'GCLOUD_TF_DOWNLOAD=always'
 - id: verify minimal-local
   waitFor:
       - converge minimal-local
@@ -39,7 +39,7 @@ steps:
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy minimal-local']
   env:
-  - 'GCLOUD_TF_DOWNLOAD=never'
+  - 'GCLOUD_TF_DOWNLOAD=always'
 
 - id: create fabric-project-local
   waitFor:
@@ -160,4 +160,4 @@ options:
     - 'TF_VAR_gsuite_admin_email=project-factory-test-admin@test.infra.cft.tips'
     - 'TF_VAR_gsuite_domain=test.infra.cft.tips'
     - 'TF_VAR_domain=test.infra.cft.tips.'
-    - 'GCLOUD_TF_DOWNLOAD=always'
+    - 'GCLOUD_TF_DOWNLOAD=never'

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -160,3 +160,6 @@ tags:
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
   _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.0'
+options:
+  machineType: 'N1_HIGHCPU_8'
+  

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -23,6 +23,7 @@ steps:
   - 'TF_VAR_gsuite_admin_email=project-factory-test-admin@test.infra.cft.tips'
   - 'TF_VAR_gsuite_domain=test.infra.cft.tips'
   - 'TF_VAR_domain=test.infra.cft.tips.'
+  - 'GCLOUD_TF_DOWNLOAD=always'
 - id: create minimal-local
   waitFor:
       - prepare
@@ -33,6 +34,8 @@ steps:
       - create minimal-local
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge minimal-local']
+  env:
+  - 'GCLOUD_TF_DOWNLOAD=never'
 - id: verify minimal-local
   waitFor:
       - converge minimal-local
@@ -43,6 +46,8 @@ steps:
     - verify minimal-local
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy minimal-local']
+  env:
+  - 'GCLOUD_TF_DOWNLOAD=never'
 
 - id: create fabric-project-local
   waitFor:

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 timeout: 3600s
 steps:
 - id: prepare
@@ -23,24 +22,133 @@ steps:
   - 'TF_VAR_billing_account=$_BILLING_ACCOUNT'
   - 'TF_VAR_gsuite_admin_email=project-factory-test-admin@test.infra.cft.tips'
   - 'TF_VAR_gsuite_domain=test.infra.cft.tips'
-- id: create
-  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'ln -s /root/.terraform.d/plugins ~/.terraform.d/plugins && source /usr/local/bin/task_helper_functions.sh && kitchen_do create']
-- id: converge
-  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'ln -s /root/.terraform.d/plugins ~/.terraform.d/plugins && source /usr/local/bin/task_helper_functions.sh && export TF_VAR_policy_id=$(gcloud access-context-manager policies list --organization="${TF_VAR_org_id:?}" --format="value(name)") && kitchen_do converge']
-  env:
   - 'TF_VAR_org_id=$_ORG_ID'
   - 'TF_VAR_domain=test.infra.cft.tips.'
-- id: verify
+- id: create minimal-local
+  waitFor:
+      - prepare
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'ln -s /root/.terraform.d/plugins ~/.terraform.d/plugins && source /usr/local/bin/task_helper_functions.sh && kitchen_do verify']
-- id: destroy
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do create minimal-local']
+- id: converge minimal-local
+  waitFor:
+      - create minimal-local
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'ln -s /root/.terraform.d/plugins ~/.terraform.d/plugins && source /usr/local/bin/task_helper_functions.sh && export TF_VAR_policy_id=$(gcloud access-context-manager policies list --organization="${TF_VAR_org_id:?}" --format="value(name)") && kitchen_do destroy']
-  env:
-  - 'TF_VAR_org_id=$_ORG_ID'
-  - 'TF_VAR_domain=test.infra.cft.tips.'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge minimal-local']
+- id: verify minimal-local
+  waitFor:
+      - converge minimal-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify minimal-local']
+- id: destroy minimal-local
+  waitFor:
+    - verify minimal-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy minimal-local']
+
+- id: create fabric-project-local
+  waitFor:
+      - prepare
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do create fabric-project-local']
+- id: converge fabric-project-local
+  waitFor:
+      - create fabric-project-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge fabric-project-local']
+- id: verify fabric-project-local
+  waitFor:
+      - converge fabric-project-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify fabric-project-local']
+- id: destroy fabric-project-local
+  waitFor:
+    - verify fabric-project-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy fabric-project-local']
+
+- id: create app-engine-local
+  waitFor:
+      - prepare
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do create app-engine-local']
+- id: converge app-engine-local
+  waitFor:
+      - create app-engine-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge app-engine-local']
+- id: verify app-engine-local
+  waitFor:
+      - converge app-engine-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify app-engine-local']
+- id: destroy app-engine-local
+  waitFor:
+    - verify app-engine-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy app-engine-local']
+
+- id: create budget-local
+  waitFor:
+      - prepare
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do create budget-local']
+- id: converge budget-local
+  waitFor:
+      - create budget-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge budget-local']
+- id: verify budget-local
+  waitFor:
+      - converge budget-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify budget-local']
+- id: destroy budget-local
+  waitFor:
+    - verify budget-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy budget-local']
+
+- id: create dynamic-shared-vpc-local
+  waitFor:
+      - prepare
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do create dynamic-shared-vpc-local']
+- id: converge dynamic-shared-vpc-local
+  waitFor:
+      - create dynamic-shared-vpc-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge dynamic-shared-vpc-local']
+- id: verify dynamic-shared-vpc-local
+  waitFor:
+      - converge dynamic-shared-vpc-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify dynamic-shared-vpc-local']
+- id: destroy dynamic-shared-vpc-local
+  waitFor:
+    - verify dynamic-shared-vpc-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy dynamic-shared-vpc-local']
+
+- id: create vpc-sc-project-local
+  waitFor:
+      - prepare
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do create vpc-sc-project-local']
+- id: converge vpc-sc-project-local
+  waitFor:
+      - create vpc-sc-project-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && export TF_VAR_policy_id=$(gcloud access-context-manager policies list --organization="${TF_VAR_org_id:?}" --format="value(name)") && kitchen_do converge vpc-sc-project-local']
+- id: verify vpc-sc-project-local
+  waitFor:
+      - converge vpc-sc-project-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify vpc-sc-project-local']
+- id: destroy vpc-sc-project-local
+  waitFor:
+    - verify vpc-sc-project-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && export TF_VAR_policy_id=$(gcloud access-context-manager policies list --organization="${TF_VAR_org_id:?}" --format="value(name)") && kitchen_do destroy vpc-sc-project-local']
 tags:
 - 'ci'
 - 'integration'


### PR DESCRIPTION
Recently CI for PF seems to be failing at the destroy step. For instance #450 
I have been unable to repro locally but my theory is that it is due to multiple gcloud destroys happening in the same build step. This aims to build them in separate build steps in parallel. 

edit: that alone did not solve the problem completely, ended up skipping gcloud for all but one example

Changelist
- parallel builds
- added global `GCLOUD_TF_DOWNLOAD=always`
- set `GCLOUD_TF_DOWNLOAD=never` for minimal example