### PR TITLE
fix tf12+ warning

### DIFF
--- a/modules/project_services/main.tf
+++ b/modules/project_services/main.tf
@@ -54,5 +54,5 @@ resource "google_project_iam_member" "project_service_identity_roles" {
 
   project = var.project_id
   role    = each.value.role
-  member  = "serviceAccount:${google_project_service_identity.project_service_identities["${each.value.api}"].email}"
+  member  = "serviceAccount:${google_project_service_identity.project_service_identities[each.value.api].email}"
 }


### PR DESCRIPTION
```
Warning: Interpolation-only expressions are deprecated

  on .terraform/modules/project-assets/modules/project_services/main.tf line 57, in resource "google_project_iam_member" "project_service_identity_roles":
  57:   member  = "serviceAccount:${google_project_service_identity.project_service_identities["${each.value.api}"].email}"
```
