### PR TITLE
add apis related outputs to main module

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,11 @@ determining that location is as follows:
 
 | Name | Description |
 |------|-------------|
+| api\_s\_account | API service account email |
+| api\_s\_account\_fmt | API service account email formatted for terraform use |
 | budget\_name | The name of the budget if created |
 | domain | The organization's domain |
+| enabled\_apis | Enabled APIs in the project |
 | group\_email | The email of the G Suite group with group_name |
 | project\_bucket\_self\_link | Project's bucket selfLink |
 | project\_bucket\_url | Project's bucket url |

--- a/outputs.tf
+++ b/outputs.tf
@@ -71,6 +71,21 @@ output "project_bucket_url" {
   description = "Project's bucket url"
 }
 
+output "api_s_account" {
+  value       = module.project-factory.api_s_account
+  description = "API service account email"
+}
+
+output "api_s_account_fmt" {
+  value       = module.project-factory.api_s_account_fmt
+  description = "API service account email formatted for terraform use"
+}
+
+output "enabled_apis" {
+  description = "Enabled APIs in the project"
+  value       = module.project-factory.enabled_apis
+}
+
 output "budget_name" {
   value       = module.budget.name
   description = "The name of the budget if created"


### PR DESCRIPTION
these were previously added to `core_project_factory` but not re-exported by top level module

useful for people who prefer to use the top level module instead of core_project_factory