### PR TITLE
Increase project prefix length

### DIFF
--- a/modules/core_project_factory/main.tf
+++ b/modules/core_project_factory/main.tf
@@ -18,7 +18,7 @@
   Project random id suffix configuration
  *****************************************/
 resource "random_id" "random_project_id_suffix" {
-  byte_length = 2
+  byte_length = 4
 }
 
 /******************************************


### PR DESCRIPTION
During extensive testing it popup that project IDs are randomly overlapping with existing projects when same names were used in different parent folders.  Problem mostly impacting development setups and infrastructures responsible for automated testing.  As result I'd like to propose to increase prefix length from 4 to 8 signs by increase of byte_length from 2 to 4