### PR TITLE
feat: add support for multiple roles to assign project service account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Extending the adopted spec, each change should have a link to its corresponding pull request appended.
 
+### [10.0.1](https://www.github.com/terraform-google-modules/terraform-google-project-factory/compare/v10.0.0...v10.0.1) (2020-12-16)
+
+
+### Bug Fixes
+
+* Pass service project number for root module ([#496](https://www.github.com/terraform-google-modules/terraform-google-project-factory/issues/496)) ([#520](https://www.github.com/terraform-google-modules/terraform-google-project-factory/issues/520)) ([29ff90f](https://www.github.com/terraform-google-modules/terraform-google-project-factory/commit/29ff90f83c0b1825d0588afe242b25cb7cfb65e8))
+
 ## [10.0.0](https://www.github.com/terraform-google-modules/terraform-google-project-factory/compare/v9.2.0...v10.0.0) (2020-12-15)
 
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ determining that location is as follows:
 | org\_id | The organization ID. | `string` | n/a | yes |
 | project\_id | The ID to give the project. If not provided, the `name` will be used. | `string` | `""` | no |
 | random\_project\_id | Adds a suffix of 4 random characters to the `project_id` | `bool` | `false` | no |
-| sa\_role | A role to give the default Service Account for the project (defaults to none) | `string` | `""` | no |
+| sa\_roles | A list of roles to give the default Service Account for the project (defaults to none) | `list(string)` | `[]` | no |
 | shared\_vpc\_subnets | List of subnets fully qualified subnet IDs (ie. projects/$project\_id/regions/$region/subnetworks/$subnet\_id) | `list(string)` | `[]` | no |
 | svpc\_host\_project\_id | The ID of the host project which hosts the shared VPC | `string` | `""` | no |
 | usage\_bucket\_name | Name of a GCS bucket to store GCE usage reports in (optional) | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ module "project-factory" {
   enable_shared_vpc_host_project     = var.enable_shared_vpc_host_project
   billing_account                    = var.billing_account
   folder_id                          = var.folder_id
-  sa_role                            = var.sa_role
+  sa_roles                           = var.sa_roles
   activate_apis                      = var.activate_apis
   activate_api_identities            = var.activate_api_identities
   usage_bucket_name                  = var.usage_bucket_name

--- a/modules/core_project_factory/main.tf
+++ b/modules/core_project_factory/main.tf
@@ -138,9 +138,9 @@ resource "google_service_account" "default_service_account" {
   Policy to operate instances in shared subnetwork
  *************************************************/
 resource "google_project_iam_member" "default_service_account_membership" {
-  count   = var.sa_role != "" ? 1 : 0
+  for_each = toset(var.sa_roles)
   project = google_project.main.project_id
-  role    = var.sa_role
+  role    = each.key
 
   member = local.s_account_fmt
 }

--- a/modules/core_project_factory/main.tf
+++ b/modules/core_project_factory/main.tf
@@ -139,8 +139,8 @@ resource "google_service_account" "default_service_account" {
  *************************************************/
 resource "google_project_iam_member" "default_service_account_membership" {
   for_each = toset(var.sa_roles)
-  project = google_project.main.project_id
-  role    = each.key
+  project  = google_project.main.project_id
+  role     = each.key
 
   member = local.s_account_fmt
 }

--- a/modules/core_project_factory/variables.tf
+++ b/modules/core_project_factory/variables.tf
@@ -77,10 +77,10 @@ variable "folder_id" {
   default     = ""
 }
 
-variable "sa_role" {
+variable "sa_roles" {
   description = "A role to give the default Service Account for the project (defaults to none)"
-  type        = string
-  default     = ""
+  type        = list(string)
+  default     = []
 }
 
 variable "activate_apis" {

--- a/modules/gsuite_enabled/README.md
+++ b/modules/gsuite_enabled/README.md
@@ -89,7 +89,7 @@ The roles granted are specifically:
 | project\_id | The ID to give the project. If not provided, the `name` will be used. | `string` | `""` | no |
 | random\_project\_id | Adds a suffix of 4 random characters to the `project_id` | `string` | `"false"` | no |
 | sa\_group | A G Suite group to place the default Service Account for the project in | `string` | `""` | no |
-| sa\_role | A role to give the default Service Account for the project (defaults to none) | `string` | `""` | no |
+| sa\_roles | A role to give the default Service Account for the project (defaults to none) | `list` | `[]` | no |
 | shared\_vpc | The ID of the host project which hosts the shared VPC | `string` | `""` | no |
 | shared\_vpc\_subnets | List of subnets fully qualified subnet IDs (ie. projects/$project\_id/regions/$region/subnetworks/$subnet\_id) | `list(string)` | `[]` | no |
 | usage\_bucket\_name | Name of a GCS bucket to store GCE usage reports in (optional) | `string` | `""` | no |

--- a/modules/gsuite_enabled/main.tf
+++ b/modules/gsuite_enabled/main.tf
@@ -83,7 +83,7 @@ module "project-factory" {
   enable_shared_vpc_host_project    = var.enable_shared_vpc_host_project
   billing_account                   = var.billing_account
   folder_id                         = var.folder_id
-  sa_role                           = var.sa_role
+  sa_roles                          = var.sa_roles
   activate_apis                     = var.activate_apis
   usage_bucket_name                 = var.usage_bucket_name
   usage_bucket_prefix               = var.usage_bucket_prefix

--- a/modules/gsuite_enabled/main.tf
+++ b/modules/gsuite_enabled/main.tf
@@ -83,12 +83,8 @@ module "project-factory" {
   enable_shared_vpc_host_project    = var.enable_shared_vpc_host_project
   billing_account                   = var.billing_account
   folder_id                         = var.folder_id
-<<<<<<< HEAD
-  sa_roles                          = var.sa_roles
-=======
   create_project_sa                 = var.create_project_sa
-  sa_role                           = var.sa_role
->>>>>>> b34f1e952aef73a1e6020db379291fd279c890b5
+  sa_roles                          = var.sa_roles
   activate_apis                     = var.activate_apis
   usage_bucket_name                 = var.usage_bucket_name
   usage_bucket_prefix               = var.usage_bucket_prefix

--- a/modules/gsuite_enabled/variables.tf
+++ b/modules/gsuite_enabled/variables.tf
@@ -78,17 +78,13 @@ variable "sa_group" {
   default     = ""
 }
 
-<<<<<<< HEAD
-variable "sa_roles" {
-=======
 variable "create_project_sa" {
   description = "Whether the default service account for the project shall be created"
   type        = bool
   default     = true
 }
 
-variable "sa_role" {
->>>>>>> b34f1e952aef73a1e6020db379291fd279c890b5
+variable "sa_roles" {
   description = "A role to give the default Service Account for the project (defaults to none)"
   default     = []
 }

--- a/modules/gsuite_enabled/variables.tf
+++ b/modules/gsuite_enabled/variables.tf
@@ -78,9 +78,9 @@ variable "sa_group" {
   default     = ""
 }
 
-variable "sa_role" {
+variable "sa_roles" {
   description = "A role to give the default Service Account for the project (defaults to none)"
-  default     = ""
+  default     = []
 }
 
 variable "activate_apis" {

--- a/modules/svpc_service_project/README.md
+++ b/modules/svpc_service_project/README.md
@@ -58,7 +58,7 @@ module "service-project" {
 | org\_id | The organization ID. | `string` | n/a | yes |
 | project\_id | The ID to give the project. If not provided, the `name` will be used. | `string` | `""` | no |
 | random\_project\_id | Adds a suffix of 4 random characters to the `project_id` | `bool` | `false` | no |
-| sa\_role | A role to give the default Service Account for the project (defaults to none) | `string` | `""` | no |
+| sa\_roles | A list of roles to give the default Service Account for the project (defaults to none) | `list` | `[]` | no |
 | shared\_vpc | The ID of the host project which hosts the shared VPC | `string` | `""` | no |
 | shared\_vpc\_subnets | List of subnets fully qualified subnet IDs (ie. projects/$project\_id/regions/$region/subnetworks/$subnet\_id) | `list(string)` | `[]` | no |
 | usage\_bucket\_name | Name of a GCS bucket to store GCE usage reports in (optional) | `string` | `""` | no |

--- a/modules/svpc_service_project/main.tf
+++ b/modules/svpc_service_project/main.tf
@@ -40,12 +40,8 @@ module "project-factory" {
   enable_shared_vpc_service_project = true
   billing_account                   = var.billing_account
   folder_id                         = var.folder_id
-<<<<<<< HEAD
-  sa_roles                          = var.sa_roles
-=======
   create_project_sa                 = var.create_project_sa
-  sa_role                           = var.sa_role
->>>>>>> b34f1e952aef73a1e6020db379291fd279c890b5
+  sa_roles                          = var.sa_roles
   activate_apis                     = var.activate_apis
   activate_api_identities           = var.activate_api_identities
   usage_bucket_name                 = var.usage_bucket_name

--- a/modules/svpc_service_project/main.tf
+++ b/modules/svpc_service_project/main.tf
@@ -40,7 +40,7 @@ module "project-factory" {
   enable_shared_vpc_service_project = true
   billing_account                   = var.billing_account
   folder_id                         = var.folder_id
-  sa_role                           = var.sa_role
+  sa_roles                          = var.sa_roles
   activate_apis                     = var.activate_apis
   activate_api_identities           = var.activate_api_identities
   usage_bucket_name                 = var.usage_bucket_name

--- a/modules/svpc_service_project/variables.tf
+++ b/modules/svpc_service_project/variables.tf
@@ -71,21 +71,15 @@ variable "group_role" {
   default     = "roles/editor"
 }
 
-<<<<<<< HEAD
-variable "sa_roles" {
-  description = "A list of roles to give the default Service Account for the project (defaults to none)"
-  default     = []
-=======
 variable "create_project_sa" {
   description = "Whether the default service account for the project shall be created"
   type        = bool
   default     = true
 }
 
-variable "sa_role" {
-  description = "A role to give the default Service Account for the project (defaults to none)"
-  default     = ""
->>>>>>> b34f1e952aef73a1e6020db379291fd279c890b5
+variable "sa_roles" {
+  description = "A list of roles to give the default Service Account for the project (defaults to none)"
+  default     = []
 }
 
 variable "activate_apis" {

--- a/modules/svpc_service_project/variables.tf
+++ b/modules/svpc_service_project/variables.tf
@@ -71,9 +71,9 @@ variable "group_role" {
   default     = "roles/editor"
 }
 
-variable "sa_role" {
-  description = "A role to give the default Service Account for the project (defaults to none)"
-  default     = ""
+variable "sa_roles" {
+  description = "A list of roles to give the default Service Account for the project (defaults to none)"
+  default     = []
 }
 
 variable "activate_apis" {

--- a/test/fixtures/full/README.md
+++ b/test/fixtures/full/README.md
@@ -15,7 +15,7 @@
 | random\_string\_for\_testing | A random string of characters to be appended to resource names to ensure uniqueness | `string` | n/a | yes |
 | region | n/a | `string` | `"us-east4"` | no |
 | sa\_group | n/a | `string` | n/a | yes |
-| sa\_role | n/a | `string` | `"roles/editor"` | no |
+| sa\_roles | n/a | `list(string)` | <pre>[<br>  "roles/editor"<br>]</pre> | no |
 | shared\_vpc | n/a | `string` | n/a | yes |
 | usage\_bucket\_name | n/a | `string` | n/a | yes |
 | usage\_bucket\_prefix | n/a | `string` | n/a | yes |
@@ -34,7 +34,7 @@
 | project\_name | n/a |
 | project\_number | n/a |
 | region | n/a |
-| sa\_role | n/a |
+| sa\_roles | n/a |
 | service\_account\_email | n/a |
 | shared\_vpc | n/a |
 | shared\_vpc\_subnet\_name\_01 | n/a |

--- a/test/fixtures/full/main.tf
+++ b/test/fixtures/full/main.tf
@@ -114,7 +114,7 @@ module "project-factory" {
   shared_vpc                        = var.shared_vpc
   enable_shared_vpc_service_project = true
   shared_vpc_subnets                = local.shared_vpc_subnets
-  sa_role                           = var.sa_role
+  sa_roles                          = var.sa_roles
   sa_group                          = var.sa_group
   lien                              = "true"
 
@@ -134,10 +134,10 @@ resource "google_service_account" "extra_service_account" {
 }
 
 resource "google_project_iam_member" "additive_sa_role" {
-  count   = var.sa_role != "" ? 1 : 0
-  project = module.project-factory.project_id
-  role    = var.sa_role
-  member  = "serviceAccount:${google_service_account.extra_service_account.email}"
+  for_each = var.sa_roles
+  project  = module.project-factory.project_id
+  role     = each.key
+  member   = "serviceAccount:${google_service_account.extra_service_account.email}"
 }
 
 resource "google_project_iam_member" "additive_shared_vpc_role" {

--- a/test/fixtures/full/outputs.tf
+++ b/test/fixtures/full/outputs.tf
@@ -74,8 +74,8 @@ output "region" {
   value = var.region
 }
 
-output "sa_role" {
-  value = var.sa_role
+output "sa_roles" {
+  value = var.sa_roles
 }
 
 output "shared_vpc" {

--- a/test/fixtures/full/variables.tf
+++ b/test/fixtures/full/variables.tf
@@ -54,9 +54,9 @@ variable "group_role" {
   type    = string
 }
 
-variable "sa_role" {
-  default = "roles/editor"
-  type    = string
+variable "sa_roles" {
+  default = ["roles/editor"]
+  type    = list(string)
 }
 
 variable "sa_group" {

--- a/variables.tf
+++ b/variables.tf
@@ -77,10 +77,10 @@ variable "group_role" {
   default     = "roles/editor"
 }
 
-variable "sa_role" {
-  description = "A role to give the default Service Account for the project (defaults to none)"
-  type        = string
-  default     = ""
+variable "sa_roles" {
+  description = "A list of roles to give the default Service Account for the project (defaults to none)"
+  type        = list(string)
+  default     = []
 }
 
 variable "activate_apis" {

--- a/variables.tf
+++ b/variables.tf
@@ -81,6 +81,7 @@ variable "sa_roles" {
   description = "A list of roles to give the default Service Account for the project (defaults to none)"
   type        = list(string)
   default     = []
+}
 
 variable "create_project_sa" {
   description = "Whether the default service account for the project shall be created"


### PR DESCRIPTION
This PR allows for the ability to bind more than one role to the created project service account