### PR TITLE
feat: expose grant_services_security_admin_role var

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ determining that location is as follows:
 | domain | The domain name (optional). | `string` | `""` | no |
 | enable\_shared\_vpc\_host\_project | If this project is a shared VPC host project. If true, you must *not* set svpc\_host\_project\_id variable. Default is false. | `bool` | `false` | no |
 | folder\_id | The ID of a folder to host this project | `string` | `""` | no |
+| grant\_services\_security\_admin\_role | Whether or not to grant Kubernetes Engine Service Agent the Security Admin role on the host project so it can manage firewall rules | `bool` | `false` | no |
 | group\_name | A group to control the project by being assigned group\_role (defaults to project editor) | `string` | `""` | no |
 | group\_role | The role to give the controlling group (group\_name) over the project (defaults to project editor) | `string` | `"roles/editor"` | no |
 | impersonate\_service\_account | An optional service account to impersonate. This cannot be used with credentials\_path. If this service account is not specified and credentials\_path is absent, the module will use Application Default Credentials. | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -67,14 +67,15 @@ module "project-factory" {
   Setting API service accounts for shared VPC
  *****************************************/
 module "shared_vpc_access" {
-  source                            = "./modules/shared_vpc_access"
-  enable_shared_vpc_service_project = var.svpc_host_project_id != "" ? true : false
-  host_project_id                   = var.svpc_host_project_id
-  service_project_id                = module.project-factory.project_id
-  active_apis                       = module.project-factory.enabled_apis
-  shared_vpc_subnets                = var.shared_vpc_subnets
-  service_project_number            = module.project-factory.project_number
-  lookup_project_numbers            = false
+  source                             = "./modules/shared_vpc_access"
+  enable_shared_vpc_service_project  = var.svpc_host_project_id != "" ? true : false
+  host_project_id                    = var.svpc_host_project_id
+  service_project_id                 = module.project-factory.project_id
+  active_apis                        = module.project-factory.enabled_apis
+  shared_vpc_subnets                 = var.shared_vpc_subnets
+  service_project_number             = module.project-factory.project_number
+  lookup_project_numbers             = false
+  grant_services_security_admin_role = var.grant_services_security_admin_role
 }
 
 /******************************************

--- a/modules/svpc_service_project/README.md
+++ b/modules/svpc_service_project/README.md
@@ -50,6 +50,7 @@ module "service-project" {
 | disable\_services\_on\_destroy | Whether project services will be disabled when the resources are destroyed | `bool` | `true` | no |
 | domain | The domain name (optional). | `string` | `""` | no |
 | folder\_id | The ID of a folder to host this project | `string` | `""` | no |
+| grant\_services\_security\_admin\_role | Whether or not to grant Kubernetes Engine Service Agent the Security Admin role on the host project so it can manage firewall rules | `bool` | `false` | no |
 | group\_name | A group to control the project by being assigned group\_role (defaults to project editor) | `string` | `""` | no |
 | group\_role | The role to give the controlling group (group\_name) over the project (defaults to project editor) | `string` | `"roles/editor"` | no |
 | impersonate\_service\_account | An optional service account to impersonate. This cannot be used with credentials\_path. If this service account is not specified and credentials\_path is absent, the module will use Application Default Credentials. | `string` | `""` | no |

--- a/modules/svpc_service_project/main.tf
+++ b/modules/svpc_service_project/main.tf
@@ -64,14 +64,15 @@ module "project-factory" {
   Setting API service accounts for shared VPC
  *****************************************/
 module "shared_vpc_access" {
-  source                            = "../shared_vpc_access"
-  host_project_id                   = var.shared_vpc
-  enable_shared_vpc_service_project = true
-  service_project_id                = module.project-factory.project_id
-  active_apis                       = module.project-factory.enabled_apis
-  shared_vpc_subnets                = var.shared_vpc_subnets
-  service_project_number            = module.project-factory.project_number
-  lookup_project_numbers            = false
+  source                             = "../shared_vpc_access"
+  host_project_id                    = var.shared_vpc
+  enable_shared_vpc_service_project  = true
+  service_project_id                 = module.project-factory.project_id
+  active_apis                        = module.project-factory.enabled_apis
+  shared_vpc_subnets                 = var.shared_vpc_subnets
+  service_project_number             = module.project-factory.project_number
+  lookup_project_numbers             = false
+  grant_services_security_admin_role = var.grant_services_security_admin_role
 }
 
 /******************************************

--- a/modules/svpc_service_project/variables.tf
+++ b/modules/svpc_service_project/variables.tf
@@ -214,3 +214,9 @@ variable "budget_alert_spent_percents" {
   type        = list(number)
   default     = [0.5, 0.7, 1.0]
 }
+
+variable "grant_services_security_admin_role" {
+  description = "Whether or not to grant Kubernetes Engine Service Agent the Security Admin role on the host project so it can manage firewall rules"
+  type        = bool
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -234,3 +234,9 @@ variable "vpc_service_control_perimeter_name" {
   type        = string
   default     = null
 }
+
+variable "grant_services_security_admin_role" {
+  description = "Whether or not to grant Kubernetes Engine Service Agent the Security Admin role on the host project so it can manage firewall rules"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
It's supported already in the shared_vpc_access submodule but not
available in upper modules. It should be exposed so caller of project
factory modules can leverage this feature.