### PR TITLE
Add force_destroy option to GCS bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ determining that location is as follows:
 | activate\_apis | The list of apis to activate within the project | `list(string)` | <pre>[<br>  "compute.googleapis.com"<br>]</pre> | no |
 | auto\_create\_network | Create the default network | `bool` | `false` | no |
 | billing\_account | The ID of the billing account to associate this project with | `string` | n/a | yes |
-| bucket\_force\_destroy | Enable to detele all objects within the GCS bucket. If you try to delete a bucket that contains objects, Terraform will fail that run. (optional) | `bool` | `false` | no |
+| bucket\_force\_destroy | Force the deletion of all objects within the GCS bucket when deleting the bucket (optional) | `bool` | `false` | no |
 | bucket\_labels | A map of key/value label pairs to assign to the bucket (optional) | `map` | `{}` | no |
 | bucket\_location | The location for a GCS bucket to create (optional) | `string` | `"US"` | no |
 | bucket\_name | A name for a GCS bucket to create (in the bucket\_project project), useful for Terraform state (optional) | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ determining that location is as follows:
 | activate\_apis | The list of apis to activate within the project | `list(string)` | <pre>[<br>  "compute.googleapis.com"<br>]</pre> | no |
 | auto\_create\_network | Create the default network | `bool` | `false` | no |
 | billing\_account | The ID of the billing account to associate this project with | `string` | n/a | yes |
+| bucket\_force\_destroy | Enable to detele all objects within the GCS bucket. If you try to delete a bucket that contains objects, Terraform will fail that run. (optional) | `bool` | `false` | no |
 | bucket\_labels | A map of key/value label pairs to assign to the bucket (optional) | `map` | `{}` | no |
 | bucket\_location | The location for a GCS bucket to create (optional) | `string` | `"US"` | no |
 | bucket\_name | A name for a GCS bucket to create (in the bucket\_project project), useful for Terraform state (optional) | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -56,6 +56,7 @@ module "project-factory" {
   bucket_location                    = var.bucket_location
   bucket_versioning                  = var.bucket_versioning
   bucket_labels                      = var.bucket_labels
+  bucket_force_destroy               = var.bucket_force_destroy
   auto_create_network                = var.auto_create_network
   disable_services_on_destroy        = var.disable_services_on_destroy
   default_service_account            = var.default_service_account

--- a/modules/core_project_factory/main.tf
+++ b/modules/core_project_factory/main.tf
@@ -278,10 +278,11 @@ resource "google_project_usage_export_bucket" "usage_report_export" {
 resource "google_storage_bucket" "project_bucket" {
   count = local.create_bucket ? 1 : 0
 
-  name     = local.project_bucket_name
-  project  = var.bucket_project == local.base_project_id ? google_project.main.project_id : var.bucket_project
-  location = var.bucket_location
-  labels   = var.bucket_labels
+  name          = local.project_bucket_name
+  project       = var.bucket_project == local.base_project_id ? google_project.main.project_id : var.bucket_project
+  location      = var.bucket_location
+  labels        = var.bucket_labels
+  force_destroy = var.bucket_force_destroy
 
   versioning {
     enabled = var.bucket_versioning

--- a/modules/core_project_factory/variables.tf
+++ b/modules/core_project_factory/variables.tf
@@ -176,7 +176,7 @@ variable "bucket_labels" {
 }
 
 variable "bucket_force_destroy" {
-  description = "Enable to detele all objects within the GCS bucket. If you try to delete a bucket that contains objects, Terraform will fail that run. (optional)"
+  description = "Force the deletion of all objects within the GCS bucket when deleting the bucket (optional)"
   type        = bool
   default     = false
 }

--- a/modules/core_project_factory/variables.tf
+++ b/modules/core_project_factory/variables.tf
@@ -175,6 +175,12 @@ variable "bucket_labels" {
   default     = {}
 }
 
+variable "bucket_force_destroy" {
+  description = "Enable to detele all objects within the GCS bucket. If you try to delete a bucket that contains objects, Terraform will fail that run. (optional)"
+  type        = bool
+  default     = false
+}
+
 variable "auto_create_network" {
   description = "Create the default network"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -176,7 +176,7 @@ variable "bucket_labels" {
 }
 
 variable "bucket_force_destroy" {
-  description = "Enable to detele all objects within the GCS bucket. If you try to delete a bucket that contains objects, Terraform will fail that run. (optional)"
+  description = "Force the deletion of all objects within the GCS bucket when deleting the bucket (optional)"
   type        = bool
   default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -175,6 +175,12 @@ variable "bucket_labels" {
   default     = {}
 }
 
+variable "bucket_force_destroy" {
+  description = "Enable to detele all objects within the GCS bucket. If you try to delete a bucket that contains objects, Terraform will fail that run. (optional)"
+  type        = bool
+  default     = false
+}
+
 variable "auto_create_network" {
   description = "Create the default network"
   type        = bool


### PR DESCRIPTION
Adding a `bucket_force_destroy` variable to allow `terraform destroy` to be run on this module more gracefully.

At the moment if any objects are left in the GCS bucket, running terraform destroy results in an error:
```
Error: Error trying to delete bucket <bucket name> containing objects without `force_destroy` set to true
```

The default value of the new variable is false, so there is no change in functionality without setting `bucket_force_destroy` to true. 