### PR TITLE
feat: add default service account name

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ determining that location is as follows:
 | budget\_monitoring\_notification\_channels | A list of monitoring notification channels in the form `[projects/{project_id}/notificationChannels/{channel_id}]`. A maximum of 5 channels are allowed. | `list(string)` | `[]` | no |
 | consumer\_quotas | The quotas configuration you want to override for the project. | <pre>list(object({<br>    service = string,<br>    metric  = string,<br>    limit   = string,<br>    value   = string,<br>  }))</pre> | `[]` | no |
 | create\_project\_sa | Whether the default service account for the project shall be created | `bool` | `true` | no |
+| project\_sa\_name | Default service account name for the project | `string` | `project-service-account` | no |
 | credentials\_path | Path to a service account credentials file with rights to run the Project Factory. If this file is absent Terraform will fall back to Application Default Credentials. | `string` | `""` | no |
 | default\_service\_account | Project default service account setting: can be one of `delete`, `deprivilege`, `disable`, or `keep`. | `string` | `"disable"` | no |
 | disable\_dependent\_services | Whether services that are enabled and which depend on this service should also be disabled when this service is destroyed. | `bool` | `true` | no |

--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ determining that location is as follows:
 | budget\_monitoring\_notification\_channels | A list of monitoring notification channels in the form `[projects/{project_id}/notificationChannels/{channel_id}]`. A maximum of 5 channels are allowed. | `list(string)` | `[]` | no |
 | consumer\_quotas | The quotas configuration you want to override for the project. | <pre>list(object({<br>    service = string,<br>    metric  = string,<br>    limit   = string,<br>    value   = string,<br>  }))</pre> | `[]` | no |
 | create\_project\_sa | Whether the default service account for the project shall be created | `bool` | `true` | no |
-| project\_sa\_name | Default service account name for the project | `string` | `project-service-account` | no |
 | credentials\_path | Path to a service account credentials file with rights to run the Project Factory. If this file is absent Terraform will fall back to Application Default Credentials. | `string` | `""` | no |
 | default\_service\_account | Project default service account setting: can be one of `delete`, `deprivilege`, `disable`, or `keep`. | `string` | `"disable"` | no |
 | disable\_dependent\_services | Whether services that are enabled and which depend on this service should also be disabled when this service is destroyed. | `bool` | `true` | no |
@@ -141,6 +140,7 @@ determining that location is as follows:
 | name | The name for the project | `string` | n/a | yes |
 | org\_id | The organization ID. | `string` | n/a | yes |
 | project\_id | The ID to give the project. If not provided, the `name` will be used. | `string` | `""` | no |
+| project\_sa\_name | Default service account name for the project. | `string` | `"project-service-account"` | no |
 | random\_project\_id | Adds a suffix of 4 random characters to the `project_id` | `bool` | `false` | no |
 | sa\_role | A role to give the default Service Account for the project (defaults to none) | `string` | `""` | no |
 | shared\_vpc\_subnets | List of subnets fully qualified subnet IDs (ie. projects/$project\_id/regions/$region/subnetworks/$subnet\_id) | `list(string)` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -42,6 +42,7 @@ module "project-factory" {
   billing_account                    = var.billing_account
   folder_id                          = var.folder_id
   create_project_sa                  = var.create_project_sa
+  project_sa_name                    = var.project_sa_name
   sa_role                            = var.sa_role
   activate_apis                      = var.activate_apis
   activate_api_identities            = var.activate_api_identities

--- a/modules/core_project_factory/main.tf
+++ b/modules/core_project_factory/main.tf
@@ -130,7 +130,7 @@ resource "google_project_default_service_accounts" "default_service_accounts" {
  *****************************************/
 resource "google_service_account" "default_service_account" {
   count        = var.create_project_sa ? 1 : 0
-  account_id   = "project-service-account"
+  account_id   = var.project_sa_name
   display_name = "${var.name} Project Service Account"
   project      = google_project.main.project_id
 }

--- a/modules/core_project_factory/variables.tf
+++ b/modules/core_project_factory/variables.tf
@@ -83,6 +83,12 @@ variable "create_project_sa" {
   default     = true
 }
 
+variable "project_sa_name" {
+  description = "Default service account name for the project."
+  type        = string
+  default     = "project-service-account"
+}
+
 variable "sa_role" {
   description = "A role to give the default Service Account for the project (defaults to none)"
   type        = string

--- a/modules/gsuite_enabled/README.md
+++ b/modules/gsuite_enabled/README.md
@@ -73,7 +73,6 @@ The roles granted are specifically:
 | consumer\_quotas | The quotas configuration you want to override for the project. | <pre>list(object({<br>    service = string,<br>    metric  = string,<br>    limit   = string,<br>    value   = string,<br>  }))</pre> | `[]` | no |
 | create\_group | Whether to create the group or not | `bool` | `false` | no |
 | create\_project\_sa | Whether the default service account for the project shall be created | `bool` | `true` | no |
-| project\_sa\_name | Default service account name for the project | `string` | `project-service-account` | no |
 | credentials\_path | Path to a service account credentials file with rights to run the Project Factory. If this file is absent Terraform will fall back to Application Default Credentials. | `string` | `""` | no |
 | default\_service\_account | Project default service account setting: can be one of `delete`, `deprivilege`, `disable`, or `keep`. | `string` | `"disable"` | no |
 | disable\_dependent\_services | Whether services that are enabled and which depend on this service should also be disabled when this service is destroyed. | `string` | `"true"` | no |
@@ -90,6 +89,7 @@ The roles granted are specifically:
 | name | The name for the project | `any` | n/a | yes |
 | org\_id | The organization ID. | `any` | n/a | yes |
 | project\_id | The ID to give the project. If not provided, the `name` will be used. | `string` | `""` | no |
+| project\_sa\_name | Default service account name for the project. | `string` | `"project-service-account"` | no |
 | random\_project\_id | Adds a suffix of 4 random characters to the `project_id` | `string` | `"false"` | no |
 | sa\_group | A G Suite group to place the default Service Account for the project in | `string` | `""` | no |
 | sa\_role | A role to give the default Service Account for the project (defaults to none) | `string` | `""` | no |

--- a/modules/gsuite_enabled/README.md
+++ b/modules/gsuite_enabled/README.md
@@ -73,6 +73,7 @@ The roles granted are specifically:
 | consumer\_quotas | The quotas configuration you want to override for the project. | <pre>list(object({<br>    service = string,<br>    metric  = string,<br>    limit   = string,<br>    value   = string,<br>  }))</pre> | `[]` | no |
 | create\_group | Whether to create the group or not | `bool` | `false` | no |
 | create\_project\_sa | Whether the default service account for the project shall be created | `bool` | `true` | no |
+| project\_sa\_name | Default service account name for the project | `string` | `project-service-account` | no |
 | credentials\_path | Path to a service account credentials file with rights to run the Project Factory. If this file is absent Terraform will fall back to Application Default Credentials. | `string` | `""` | no |
 | default\_service\_account | Project default service account setting: can be one of `delete`, `deprivilege`, `disable`, or `keep`. | `string` | `"disable"` | no |
 | disable\_dependent\_services | Whether services that are enabled and which depend on this service should also be disabled when this service is destroyed. | `string` | `"true"` | no |

--- a/modules/gsuite_enabled/main.tf
+++ b/modules/gsuite_enabled/main.tf
@@ -84,6 +84,7 @@ module "project-factory" {
   billing_account                   = var.billing_account
   folder_id                         = var.folder_id
   create_project_sa                 = var.create_project_sa
+  project_sa_name                   = var.project_sa_name
   sa_role                           = var.sa_role
   activate_apis                     = var.activate_apis
   usage_bucket_name                 = var.usage_bucket_name

--- a/modules/gsuite_enabled/variables.tf
+++ b/modules/gsuite_enabled/variables.tf
@@ -84,6 +84,12 @@ variable "create_project_sa" {
   default     = true
 }
 
+variable "project_sa_name" {
+  description = "Default service account name for the project."
+  type        = string
+  default     = "project-service-account"
+}
+
 variable "sa_role" {
   description = "A role to give the default Service Account for the project (defaults to none)"
   default     = ""

--- a/modules/svpc_service_project/README.md
+++ b/modules/svpc_service_project/README.md
@@ -44,6 +44,7 @@ module "service-project" {
 | budget\_amount | The amount to use for a budget alert | `number` | `null` | no |
 | budget\_monitoring\_notification\_channels | A list of monitoring notification channels in the form `[projects/{project_id}/notificationChannels/{channel_id}]`. A maximum of 5 channels are allowed. | `list(string)` | `[]` | no |
 | create\_project\_sa | Whether the default service account for the project shall be created | `bool` | `true` | no |
+| project\_sa\_name | Default service account name for the project | `string` | `project-service-account` | no |
 | credentials\_path | Path to a service account credentials file with rights to run the Project Factory. If this file is absent Terraform will fall back to Application Default Credentials. | `string` | `""` | no |
 | default\_service\_account | Project default service account setting: can be one of `delete`, `deprivilege`, `disable`, or `keep`. | `string` | `"disable"` | no |
 | disable\_dependent\_services | Whether services that are enabled and which depend on this service should also be disabled when this service is destroyed. | `bool` | `true` | no |

--- a/modules/svpc_service_project/README.md
+++ b/modules/svpc_service_project/README.md
@@ -44,7 +44,6 @@ module "service-project" {
 | budget\_amount | The amount to use for a budget alert | `number` | `null` | no |
 | budget\_monitoring\_notification\_channels | A list of monitoring notification channels in the form `[projects/{project_id}/notificationChannels/{channel_id}]`. A maximum of 5 channels are allowed. | `list(string)` | `[]` | no |
 | create\_project\_sa | Whether the default service account for the project shall be created | `bool` | `true` | no |
-| project\_sa\_name | Default service account name for the project | `string` | `project-service-account` | no |
 | credentials\_path | Path to a service account credentials file with rights to run the Project Factory. If this file is absent Terraform will fall back to Application Default Credentials. | `string` | `""` | no |
 | default\_service\_account | Project default service account setting: can be one of `delete`, `deprivilege`, `disable`, or `keep`. | `string` | `"disable"` | no |
 | disable\_dependent\_services | Whether services that are enabled and which depend on this service should also be disabled when this service is destroyed. | `bool` | `true` | no |
@@ -60,6 +59,7 @@ module "service-project" {
 | name | The name for the project | `string` | n/a | yes |
 | org\_id | The organization ID. | `string` | n/a | yes |
 | project\_id | The ID to give the project. If not provided, the `name` will be used. | `string` | `""` | no |
+| project\_sa\_name | Default service account name for the project. | `string` | `"project-service-account"` | no |
 | random\_project\_id | Adds a suffix of 4 random characters to the `project_id` | `bool` | `false` | no |
 | sa\_role | A role to give the default Service Account for the project (defaults to none) | `string` | `""` | no |
 | shared\_vpc | The ID of the host project which hosts the shared VPC | `string` | `""` | no |

--- a/modules/svpc_service_project/main.tf
+++ b/modules/svpc_service_project/main.tf
@@ -41,6 +41,7 @@ module "project-factory" {
   billing_account                   = var.billing_account
   folder_id                         = var.folder_id
   create_project_sa                 = var.create_project_sa
+  project_sa_name                   = var.project_sa_name
   sa_role                           = var.sa_role
   activate_apis                     = var.activate_apis
   activate_api_identities           = var.activate_api_identities

--- a/modules/svpc_service_project/variables.tf
+++ b/modules/svpc_service_project/variables.tf
@@ -77,6 +77,12 @@ variable "create_project_sa" {
   default     = true
 }
 
+variable "project_sa_name" {
+  description = "Default service account name for the project."
+  type        = string
+  default     = "project-service-account"
+}
+
 variable "sa_role" {
   description = "A role to give the default Service Account for the project (defaults to none)"
   default     = ""

--- a/variables.tf
+++ b/variables.tf
@@ -83,6 +83,12 @@ variable "create_project_sa" {
   default     = true
 }
 
+variable "project_sa_name" {
+  description = "Default service account name for the project."
+  type        = string
+  default     = "project-service-account"
+}
+
 variable "sa_role" {
   description = "A role to give the default Service Account for the project (defaults to none)"
   type        = string


### PR DESCRIPTION
Make the creation of the service account more flexible, allowing the name change.