### PR TITLE
Change Quota Manager Terraform Required Version

### DIFF
--- a/modules/quota_manager/versions.tf
+++ b/modules/quota_manager/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.13.0"
 
   required_providers {
     google-beta = ">= 3.1, < 4.0"


### PR DESCRIPTION
The root module support `>= 0.13.0`. There is no reason for one single module to break for existing users on Terraform 0.14, especially with the new release.

I have set it to be consistent with the root module.