### PR TITLE
Simplify project_id output in core_project_factory

### DIFF
--- a/modules/core_project_factory/outputs.tf
+++ b/modules/core_project_factory/outputs.tf
@@ -19,8 +19,13 @@ output "project_name" {
 }
 
 output "project_id" {
-  value      = module.project_services.project_id
-  depends_on = [module.project_services]
+  value = module.project_services.project_id
+  depends_on = [
+    module.project_services,
+    google_project.main,
+    google_compute_shared_vpc_service_project.shared_vpc_attachment,
+    google_compute_shared_vpc_host_project.shared_vpc_host,
+  ]
 }
 
 output "project_number" {

--- a/modules/core_project_factory/outputs.tf
+++ b/modules/core_project_factory/outputs.tf
@@ -19,15 +19,7 @@ output "project_name" {
 }
 
 output "project_id" {
-  value = element(
-    concat(
-      [module.project_services.project_id],
-      [google_project.main.project_id],
-      [var.enable_shared_vpc_service_project ? google_compute_shared_vpc_service_project.shared_vpc_attachment[0].id : ""],
-      [var.enable_shared_vpc_host_project ? google_compute_shared_vpc_host_project.shared_vpc_host[0].id : ""],
-    ),
-    0,
-  )
+  value      = module.project_services.project_id
   depends_on = [module.project_services]
 }
 


### PR DESCRIPTION
I ran into a case where somehow `google_compute_shared_vpc_service_project.shared_vpc_attachment` was an "empty tuple" in the state, and this output was failing because it was trying to index into it. I came across https://github.com/hashicorp/terraform/issues/25578, which might be related, but it does still happen with the latest version of Terraform as of opening this bug (v0.14.9).

Regardless, it seems to me that all this is doing is building a list then taking the first element, so the one-liner should be equivalent and avoids this error.