### PR TITLE
Adding Support for Mac M1 (Upgrade null/random versions)

### DIFF
--- a/modules/core_project_factory/versions.tf
+++ b/modules/core_project_factory/versions.tf
@@ -28,11 +28,11 @@ terraform {
     }
     null = {
       source  = "hashicorp/null"
-      version = "~> 2.1"
+      version = ">= 2.1"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 2.2"
+      version = ">= 2.2"
     }
   }
 }


### PR DESCRIPTION
* Allowing newer versions of null/random provider
* Newer versions of nul//random support Mac M1 natively

Fixed #582 