### PR TITLE
feat: add support for uniform_bucket_level_access

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ determining that location is as follows:
 | bucket\_location | The location for a GCS bucket to create (optional) | `string` | `"US"` | no |
 | bucket\_name | A name for a GCS bucket to create (in the bucket\_project project), useful for Terraform state (optional) | `string` | `""` | no |
 | bucket\_project | A project to create a GCS bucket (bucket\_name) in, useful for Terraform state (optional) | `string` | `""` | no |
-| bucket\_ula | Enable Uniform Bucket Level Access | `bool` | `false` | no |
+| bucket\_ula | Enable Uniform Bucket Level Access | `bool` | `true` | no |
 | bucket\_versioning | Enable versioning for a GCS bucket to create (optional) | `bool` | `false` | no |
 | budget\_alert\_pubsub\_topic | The name of the Cloud Pub/Sub topic where budget related messages will be published, in the form of `projects/{project_id}/topics/{topic_id}` | `string` | `null` | no |
 | budget\_alert\_spent\_percents | A list of percentages of the budget to alert on when threshold is exceeded | `list(number)` | <pre>[<br>  0.5,<br>  0.7,<br>  1<br>]</pre> | no |

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ determining that location is as follows:
 | bucket\_location | The location for a GCS bucket to create (optional) | `string` | `"US"` | no |
 | bucket\_name | A name for a GCS bucket to create (in the bucket\_project project), useful for Terraform state (optional) | `string` | `""` | no |
 | bucket\_project | A project to create a GCS bucket (bucket\_name) in, useful for Terraform state (optional) | `string` | `""` | no |
+| bucket\_ula | Enable Uniform Bucket Level Access | `bool` | `false` | no |
 | bucket\_versioning | Enable versioning for a GCS bucket to create (optional) | `bool` | `false` | no |
 | budget\_alert\_pubsub\_topic | The name of the Cloud Pub/Sub topic where budget related messages will be published, in the form of `projects/{project_id}/topics/{topic_id}` | `string` | `null` | no |
 | budget\_alert\_spent\_percents | A list of percentages of the budget to alert on when threshold is exceeded | `list(number)` | <pre>[<br>  0.5,<br>  0.7,<br>  1<br>]</pre> | no |

--- a/main.tf
+++ b/main.tf
@@ -58,6 +58,7 @@ module "project-factory" {
   bucket_versioning                  = var.bucket_versioning
   bucket_labels                      = var.bucket_labels
   bucket_force_destroy               = var.bucket_force_destroy
+  bucket_ula                         = var.bucket_ula
   auto_create_network                = var.auto_create_network
   disable_services_on_destroy        = var.disable_services_on_destroy
   default_service_account            = var.default_service_account

--- a/modules/core_project_factory/main.tf
+++ b/modules/core_project_factory/main.tf
@@ -278,11 +278,12 @@ resource "google_project_usage_export_bucket" "usage_report_export" {
 resource "google_storage_bucket" "project_bucket" {
   count = local.create_bucket ? 1 : 0
 
-  name          = local.project_bucket_name
-  project       = var.bucket_project == local.base_project_id ? google_project.main.project_id : var.bucket_project
-  location      = var.bucket_location
-  labels        = var.bucket_labels
-  force_destroy = var.bucket_force_destroy
+  name                        = local.project_bucket_name
+  project                     = var.bucket_project == local.base_project_id ? google_project.main.project_id : var.bucket_project
+  location                    = var.bucket_location
+  labels                      = var.bucket_labels
+  force_destroy               = var.bucket_force_destroy
+  uniform_bucket_level_access = var.bucket_ula
 
   versioning {
     enabled = var.bucket_versioning

--- a/modules/core_project_factory/variables.tf
+++ b/modules/core_project_factory/variables.tf
@@ -187,6 +187,12 @@ variable "bucket_force_destroy" {
   default     = false
 }
 
+variable "bucket_ula" {
+  description = "Enable Uniform Bucket Level Access"
+  type        = bool
+  default     = false
+}
+
 variable "auto_create_network" {
   description = "Create the default network"
   type        = bool

--- a/modules/core_project_factory/variables.tf
+++ b/modules/core_project_factory/variables.tf
@@ -190,7 +190,7 @@ variable "bucket_force_destroy" {
 variable "bucket_ula" {
   description = "Enable Uniform Bucket Level Access"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "auto_create_network" {

--- a/variables.tf
+++ b/variables.tf
@@ -187,6 +187,12 @@ variable "bucket_force_destroy" {
   default     = false
 }
 
+variable "bucket_ula" {
+  description = "Enable Uniform Bucket Level Access"
+  type        = bool
+  default     = false
+}
+
 variable "auto_create_network" {
   description = "Create the default network"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -190,7 +190,7 @@ variable "bucket_force_destroy" {
 variable "bucket_ula" {
   description = "Enable Uniform Bucket Level Access"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "auto_create_network" {


### PR DESCRIPTION
Fixes #586 
Adding a variable to enable uniform-bucket-level access on the project bucket if users wish to.
Default is kept false so no change to integration tests, the module remains the same in the default config
This is considered a [policy](https://docs.accurics.com/projects/accurics-terrascan/en/latest/policies/gcp/) violation by terrascan on accurics.gcp.IAM.122

P.S I know we can turn off the bucket creation but I would rather not do the same every time I want to make a project with this module