### PR TITLE
feat: allow budget display name customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ determining that location is as follows:
 | budget\_alert\_pubsub\_topic | The name of the Cloud Pub/Sub topic where budget related messages will be published, in the form of `projects/{project_id}/topics/{topic_id}` | `string` | `null` | no |
 | budget\_alert\_spent\_percents | A list of percentages of the budget to alert on when threshold is exceeded | `list(number)` | <pre>[<br>  0.5,<br>  0.7,<br>  1<br>]</pre> | no |
 | budget\_amount | The amount to use for a budget alert | `number` | `null` | no |
+| budget\_display\_name | The display name of the budget. If not set defaults to `Budget For <projects[0]|All Projects>` | `string` | `null` | no |
 | budget\_monitoring\_notification\_channels | A list of monitoring notification channels in the form `[projects/{project_id}/notificationChannels/{channel_id}]`. A maximum of 5 channels are allowed. | `list(string)` | `[]` | no |
 | consumer\_quotas | The quotas configuration you want to override for the project. | <pre>list(object({<br>    service = string,<br>    metric  = string,<br>    limit   = string,<br>    value   = string,<br>  }))</pre> | `[]` | no |
 | create\_project\_sa | Whether the default service account for the project shall be created | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -93,6 +93,7 @@ module "budget" {
   alert_spent_percents             = var.budget_alert_spent_percents
   alert_pubsub_topic               = var.budget_alert_pubsub_topic
   monitoring_notification_channels = var.budget_monitoring_notification_channels
+  display_name                     = var.budget_display_name != null ? var.budget_display_name : null
 }
 
 /******************************************

--- a/variables.tf
+++ b/variables.tf
@@ -217,6 +217,12 @@ variable "budget_amount" {
   default     = null
 }
 
+variable "budget_display_name" {
+  description = "The display name of the budget. If not set defaults to `Budget For <projects[0]|All Projects>` "
+  type        = string
+  default     = null
+}
+
 variable "budget_alert_pubsub_topic" {
   description = "The name of the Cloud Pub/Sub topic where budget related messages will be published, in the form of `projects/{project_id}/topics/{topic_id}`"
   type        = string


### PR DESCRIPTION
Hello, this PR allows the user to customize the budget display name, as it is already allowed by the budget submodule.

Thanks.