### PR TITLE
fix: Using project_id output is not forcing to wait for the project creation

### DIFF
--- a/modules/fabric-project/outputs.tf
+++ b/modules/fabric-project/outputs.tf
@@ -16,7 +16,7 @@
 
 output "project_id" {
   description = "Project id (depends on services)."
-  value       = google_project.project.project_id
+  value       = trimprefix(google_project.project.id, "projects/")
   depends_on  = [google_project_service.project_services]
 }
 


### PR DESCRIPTION
This fixes #598. 

Using `project_id` output with this fix will force terraform to wait on project creation and resolve dependencies properly. This is primarily fix for a case when there are datasources that are gathering any data using `project_id`. These datasources are run immediately and fail in plan phase, because `project_id` value output was available immediately, not after creating the project. 

One warning to consider though. After this change `project_id` output value will not be available until after apply. This causes terraform to error if `project_id` output is used anywhere in for_each clauses. Terraform cannot handle resources without knowing upfront how many resources there will be. To avoid that, it is needed to perform `terraform apply -target module.project` to create a project first, then second standard apply to create resources that are depending on it. 

I haven't run any tests, because I don't know whether there is any existing test env or every contributor should test on their own gcp org. 
