### PR TITLE
added time_sleep and dependancies on shared vpc attachment

### DIFF
--- a/modules/core_project_factory/main.tf
+++ b/modules/core_project_factory/main.tf
@@ -101,7 +101,7 @@ module "project_services" {
   Shared VPC configuration
  *****************************************/
 resource "time_sleep" "wait_5_seconds" {
-  depends_on = [google_access_context_manager_service_perimeter_resource.service_perimeter_attachment[0],google_project_service.enable_access_context_manager]
+  depends_on      = [google_access_context_manager_service_perimeter_resource.service_perimeter_attachment[0], google_project_service.enable_access_context_manager]
   create_duration = "5s"
 }
 

--- a/modules/core_project_factory/main.tf
+++ b/modules/core_project_factory/main.tf
@@ -101,7 +101,8 @@ module "project_services" {
   Shared VPC configuration
  *****************************************/
 resource "time_sleep" "wait_5_seconds" {
-  depends_on      = [google_access_context_manager_service_perimeter_resource.service_perimeter_attachment[0], google_project_service.enable_access_context_manager]
+  count           = var.vpc_service_control_attach_enabled ? 1 : 0
+  depends_on      = [google_access_context_manager_service_perimeter_resource.service_perimeter_attachment[0], google_project_service.enable_access_context_manager[0]]
   create_duration = "5s"
 }
 
@@ -111,7 +112,7 @@ resource "google_compute_shared_vpc_service_project" "shared_vpc_attachment" {
   count           = var.enable_shared_vpc_service_project ? 1 : 0
   host_project    = var.shared_vpc
   service_project = google_project.main.project_id
-  depends_on      = [time_sleep.wait_5_seconds, module.project_services]
+  depends_on      = [time_sleep.wait_5_seconds[0], module.project_services]
 }
 
 resource "google_compute_shared_vpc_host_project" "shared_vpc_host" {

--- a/modules/core_project_factory/main.tf
+++ b/modules/core_project_factory/main.tf
@@ -100,13 +100,18 @@ module "project_services" {
 /******************************************
   Shared VPC configuration
  *****************************************/
+resource "time_sleep" "wait_5_seconds" {
+  depends_on = [google_access_context_manager_service_perimeter_resource.service_perimeter_attachment[0],google_project_service.enable_access_context_manager]
+  create_duration = "5s"
+}
+
 resource "google_compute_shared_vpc_service_project" "shared_vpc_attachment" {
   provider = google-beta
 
   count           = var.enable_shared_vpc_service_project ? 1 : 0
   host_project    = var.shared_vpc
   service_project = google_project.main.project_id
-  depends_on      = [module.project_services]
+  depends_on      = [time_sleep.wait_5_seconds, module.project_services]
 }
 
 resource "google_compute_shared_vpc_host_project" "shared_vpc_host" {


### PR DESCRIPTION
This fixes #607

Service project needs to be added to the VPC-SC perimeter before it get attached to the SharedVPC (that is part of the same VPC-SC Perimeter) else you get a `Error 403: Request is prohibited by organization's policy. vpcServiceControlsUniqueIdentifier`

Adding `google_access_context_manager_service_perimeter_resource.service_perimeter_attachment[0]` to `depends_on` for  `"google_compute_shared_vpc_service_project" "shared_vpc_attachment"` doesn't work either as the VPC-SC api seems to be eventually consistent.

Adding a 5s `time_sleep` although not ideal fixes the issue.    