### PR TITLE
fix: plumb grant_services_network_role for root module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -78,6 +78,7 @@ module "shared_vpc_access" {
   service_project_number             = module.project-factory.project_number
   lookup_project_numbers             = false
   grant_services_security_admin_role = var.grant_services_security_admin_role
+  grant_services_network_role        = var.grant_services_network_role
 }
 
 /******************************************


### PR DESCRIPTION
Looks like we forgot to add this to the root module in #618 