### PR TITLE
Pin random provider to a specific version.

### DIFF
--- a/examples/app_engine/versions.tf
+++ b/examples/app_engine/versions.tf
@@ -28,6 +28,7 @@ terraform {
     }
     random = {
       source = "hashicorp/random"
+      version = "~> 3.0"
     }
   }
 }

--- a/examples/budget_project/versions.tf
+++ b/examples/budget_project/versions.tf
@@ -28,6 +28,7 @@ terraform {
     }
     random = {
       source = "hashicorp/random"
+      version = "~> 3.0"
     }
   }
 }

--- a/examples/fabric_project/versions.tf
+++ b/examples/fabric_project/versions.tf
@@ -22,6 +22,7 @@ terraform {
     }
     random = {
       source = "hashicorp/random"
+      version = "~> 3.0"
     }
   }
 }

--- a/examples/gke_shared_vpc/versions.tf
+++ b/examples/gke_shared_vpc/versions.tf
@@ -28,6 +28,7 @@ terraform {
     }
     random = {
       source = "hashicorp/random"
+      version = "~> 3.0"
     }
   }
 }

--- a/examples/group_project/versions.tf
+++ b/examples/group_project/versions.tf
@@ -31,6 +31,7 @@ terraform {
     }
     random = {
       source = "hashicorp/random"
+      version = "~> 3.0"
     }
   }
 }

--- a/examples/project-hierarchy/versions.tf
+++ b/examples/project-hierarchy/versions.tf
@@ -31,6 +31,7 @@ terraform {
     }
     random = {
       source = "hashicorp/random"
+      version = "~> 3.0"
     }
   }
 }

--- a/examples/quota_project/versions.tf
+++ b/examples/quota_project/versions.tf
@@ -28,6 +28,7 @@ terraform {
     }
     random = {
       source = "hashicorp/random"
+      version = "~> 3.0"
     }
   }
 }

--- a/examples/simple_project/versions.tf
+++ b/examples/simple_project/versions.tf
@@ -28,6 +28,7 @@ terraform {
     }
     random = {
       source = "hashicorp/random"
+      version = "~> 3.0"
     }
   }
 }

--- a/modules/core_project_factory/versions.tf
+++ b/modules/core_project_factory/versions.tf
@@ -32,7 +32,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 2.2"
+      version = "~= 3.0"
     }
   }
 }

--- a/modules/core_project_factory/versions.tf
+++ b/modules/core_project_factory/versions.tf
@@ -32,7 +32,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "~= 3.0"
+      version = "~> 3.0"
     }
   }
 }


### PR DESCRIPTION
Reduce the possibility of future releases including breaking changes from the random provider.