### PR TITLE
fix: Allow explicit Provider configuration in Module

### DIFF
--- a/modules/gsuite_enabled/versions.tf
+++ b/modules/gsuite_enabled/versions.tf
@@ -16,8 +16,15 @@
 
 terraform {
   required_version = ">= 0.13"
-
   required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.50, < 4.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 3.50, < 4.0"
+    }
     gsuite = {
       source  = "DeviaVir/gsuite"
       version = "~> 0.1"

--- a/modules/svpc_service_project/versions.tf
+++ b/modules/svpc_service_project/versions.tf
@@ -16,6 +16,16 @@
 
 terraform {
   required_version = ">=0.13.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.50, < 4.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 3.50, < 4.0"
+    }
+  }
   provider_meta "google" {
     module_name = "blueprints/terraform/terraform-google-project-factory:svpc_service_project/v11.2.1"
   }

--- a/versions.tf
+++ b/versions.tf
@@ -16,6 +16,16 @@
 
 terraform {
   required_version = ">=0.13.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.50, < 4.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 3.50, < 4.0"
+    }
+  }
   provider_meta "google" {
     module_name = "blueprints/terraform/terraform-google-project-factory/v11.2.1"
   }


### PR DESCRIPTION
Closes #623

This change will enable explicit provider configuration, e.g:

```terraform
provider "google" {
  alias = "service_account"

  credentials = var.service_account_credentials
}

module "project-factory" {
  providers = {
    google = google.service_account
  }

  # ...
}
```

I chose the version constraints (`>= 3.50, < 4.0`) because that is the minimum required to meet every nested module's requirements. `modules/shared_vpc_access` requires `>= 3.43, <4.0` but `3.43` would not meet the `>= 3.50, < 4.0` requirements of `modules/core_project_factory`. 

I ran some checks and it's already not possible to use any part of this project with a version less than `3.50` because there's already an implicit dependency on `>= 3.50` -- this change just makes it explicit, _everything_ makes use of something with a dependency of `>= 3.50` (including `gsuite_group`). Therefore, I do not believe this is a breaking change.

I reviewed the nested modules `required_providers` while I was doing this. Every one has a `required_providers` except `svpc_service_project` so I have added that to this PR so any provider configuration is passed through.

- [x] [svpc_service_project](https://github.com/terraform-google-modules/terraform-google-project-factory/blob/master/modules/svpc_service_project/versions.tf)
- [x] [app_engine](https://github.com/terraform-google-modules/terraform-google-project-factory/blob/master/modules/app_engine/versions.tf)
- [x] [budget](https://github.com/terraform-google-modules/terraform-google-project-factory/blob/master/modules/budget/versions.tf)
- [x] [core_project_factory](https://github.com/terraform-google-modules/terraform-google-project-factory/blob/master/modules/core_project_factory/versions.tf)
- [x] [fabric-project](https://github.com/terraform-google-modules/terraform-google-project-factory/blob/master/modules/fabric-project/versions.tf)
- [x] [gsuite_enabled](https://github.com/terraform-google-modules/terraform-google-project-factory/blob/master/modules/gsuite_enabled/versions.tf)
- [x] [gsuite_group](https://github.com/terraform-google-modules/terraform-google-project-factory/blob/master/modules/gsuite_group/versions.tf)
- [x] [project_services](https://github.com/terraform-google-modules/terraform-google-project-factory/blob/master/modules/project_services/versions.tf)
- [x] [quota_manager](https://github.com/terraform-google-modules/terraform-google-project-factory/blob/master/modules/quota_manager/versions.tf)
- [x] [shared_vpc_access](https://github.com/terraform-google-modules/terraform-google-project-factory/blob/master/modules/shared_vpc_access/versions.tf)