### PR TITLE
feat!: Budget module should support filtering on labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ determining that location is as follows:
 | budget\_alert\_spent\_percents | A list of percentages of the budget to alert on when threshold is exceeded | `list(number)` | <pre>[<br>  0.5,<br>  0.7,<br>  1<br>]</pre> | no |
 | budget\_amount | The amount to use for a budget alert | `number` | `null` | no |
 | budget\_display\_name | The display name of the budget. If not set defaults to `Budget For <projects[0]|All Projects>` | `string` | `null` | no |
+| budget\_labels | A single label and value pair specifying that usage from only this set of labeled resources should be included in the budget. | `map(string)` | `{}` | no |
 | budget\_monitoring\_notification\_channels | A list of monitoring notification channels in the form `[projects/{project_id}/notificationChannels/{channel_id}]`. A maximum of 5 channels are allowed. | `list(string)` | `[]` | no |
 | consumer\_quotas | The quotas configuration you want to override for the project. | <pre>list(object({<br>    service = string,<br>    metric  = string,<br>    limit   = string,<br>    value   = string,<br>  }))</pre> | `[]` | no |
 | create\_project\_sa | Whether the default service account for the project shall be created | `bool` | `true` | no |

--- a/examples/app_engine/versions.tf
+++ b/examples/app_engine/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.30"
+      version = "~> 4.5"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.30"
+      version = "~> 4.5"
     }
     null = {
       source  = "hashicorp/null"

--- a/examples/budget_project/README.md
+++ b/examples/budget_project/README.md
@@ -18,7 +18,6 @@ It will do the following:
 | budget\_credit\_types\_treatment | Specifies how credits should be treated when determining spend for threshold calculations | `string` | `"EXCLUDE_ALL_CREDITS"` | no |
 | budget\_services | A list of services to be included in the budget | `list(string)` | <pre>[<br>  "6F81-5844-456A",<br>  "A1E8-BE35-7EBC"<br>]</pre> | no |
 | folder\_id | The ID of a folder to host this project. | `string` | `""` | no |
-| location\_id | The location to serve the app from. | `string` | `"us-east4"` | no |
 | org\_id | The organization ID. | `string` | n/a | yes |
 | parent\_project\_id | The project\_id of the parent project to add as an additional project for the budget | `string` | n/a | yes |
 

--- a/examples/budget_project/main.tf
+++ b/examples/budget_project/main.tf
@@ -48,4 +48,7 @@ module "additional_budget" {
   services               = var.budget_services
   alert_spent_percents   = var.budget_alert_spent_percents
   alert_pubsub_topic     = "projects/${module.budget_project.project_id}/topics/${google_pubsub_topic.budget.name}"
+  labels = {
+    "cost-center" : "dept-x"
+  }
 }

--- a/examples/budget_project/variables.tf
+++ b/examples/budget_project/variables.tf
@@ -35,11 +35,6 @@ variable "billing_account" {
   type        = string
 }
 
-variable "location_id" {
-  description = "The location to serve the app from."
-  default     = "us-east4"
-}
-
 variable "budget_amount" {
   description = "The amount to use for the budget"
   default     = 10

--- a/examples/budget_project/versions.tf
+++ b/examples/budget_project/versions.tf
@@ -19,15 +19,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.30"
-    }
-    google-beta = {
-      source  = "hashicorp/google-beta"
-      version = "~> 3.30"
-    }
-    null = {
-      source  = "hashicorp/null"
-      version = "~> 2.1"
+      version = "~> 4.5"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/essential_contacts/versions.tf
+++ b/examples/essential_contacts/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = "~> 4.5"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.0"
+      version = "~> 4.5"
     }
   }
 }

--- a/examples/fabric_project/versions.tf
+++ b/examples/fabric_project/versions.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.30"
+      version = "~> 4.5"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/gke_shared_vpc/versions.tf
+++ b/examples/gke_shared_vpc/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.30"
+      version = "~> 4.5"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.30"
+      version = "~> 4.5"
     }
     null = {
       source  = "hashicorp/null"

--- a/examples/group_project/versions.tf
+++ b/examples/group_project/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.30"
+      version = "~> 4.5"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.30"
+      version = "~> 4.5"
     }
     gsuite = {
       source  = "deviavir/gsuite"

--- a/examples/project-hierarchy/versions.tf
+++ b/examples/project-hierarchy/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.30"
+      version = "~> 4.5"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.30"
+      version = "~> 4.5"
     }
     gsuite = {
       source  = "deviavir/gsuite"

--- a/examples/project_services/versions.tf
+++ b/examples/project_services/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.30"
+      version = "~> 4.5"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.38"
+      version = "~> 4.5"
     }
   }
 }

--- a/examples/quota_project/versions.tf
+++ b/examples/quota_project/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.54"
+      version = "~> 4.5"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.54"
+      version = "~> 4.5"
     }
     null = {
       source  = "hashicorp/null"

--- a/examples/shared_vpc/main.tf
+++ b/examples/shared_vpc/main.tf
@@ -38,7 +38,7 @@ module "host-project" {
  *****************************************/
 module "vpc" {
   source  = "terraform-google-modules/network/google"
-  version = "~> 3.0"
+  version = "~> 4.1"
 
   project_id                             = module.host-project.project_id
   network_name                           = var.network_name

--- a/examples/shared_vpc/versions.tf
+++ b/examples/shared_vpc/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.30"
+      version = "~> 4.5"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.30"
+      version = "~> 4.5"
     }
     null = {
       source  = "hashicorp/null"

--- a/examples/simple_project/versions.tf
+++ b/examples/simple_project/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.30"
+      version = "~> 4.5"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.38"
+      version = "~> 4.5"
     }
     null = {
       source  = "hashicorp/null"

--- a/main.tf
+++ b/main.tf
@@ -96,6 +96,7 @@ module "budget" {
   alert_pubsub_topic               = var.budget_alert_pubsub_topic
   monitoring_notification_channels = var.budget_monitoring_notification_channels
   display_name                     = var.budget_display_name != null ? var.budget_display_name : null
+  labels                           = var.budget_labels
 }
 
 /******************************************

--- a/modules/budget/README.md
+++ b/modules/budget/README.md
@@ -27,6 +27,7 @@ module "project_myproject" {
 | create\_budget | If the budget should be created | `bool` | `true` | no |
 | credit\_types\_treatment | Specifies how credits should be treated when determining spend for threshold calculations | `string` | `"INCLUDE_ALL_CREDITS"` | no |
 | display\_name | The display name of the budget. If not set defaults to `Budget For <projects[0]|All Projects>` | `string` | `null` | no |
+| labels | A single label and value pair specifying that usage from only this set of labeled resources should be included in the budget. | `map(string)` | `{}` | no |
 | monitoring\_notification\_channels | A list of monitoring notification channels in the form `[projects/{project_id}/notificationChannels/{channel_id}]`. A maximum of 5 channels are allowed. | `list(string)` | `[]` | no |
 | projects | The project ids to include in this budget. If empty budget will include all projects | `list(string)` | n/a | yes |
 | services | A list of services ids to be included in the budget. If omitted, all services will be included in the budget. Service ids can be found at https://cloud.google.com/skus/ | `list(string)` | `null` | no |

--- a/modules/budget/main.tf
+++ b/modules/budget/main.tf
@@ -45,6 +45,7 @@ resource "google_billing_budget" "budget" {
     projects               = local.projects
     credit_types_treatment = var.credit_types_treatment
     services               = local.services
+    labels                 = var.labels
   }
 
   amount {

--- a/modules/budget/variables.tf
+++ b/modules/budget/variables.tf
@@ -70,3 +70,13 @@ variable "monitoring_notification_channels" {
   type        = list(string)
   default     = []
 }
+
+variable "labels" {
+  description = "A single label and value pair specifying that usage from only this set of labeled resources should be included in the budget."
+  type        = map(string)
+  default     = {}
+  validation {
+    condition     = length(var.labels) <= 1
+    error_message = "Only 0 or 1 labels may be supplied for the budget filter."
+  }
+}

--- a/modules/budget/versions.tf
+++ b/modules/budget/versions.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.5, < 5.0"
+      version = "~> 4.5"
     }
   }
 

--- a/modules/budget/versions.tf
+++ b/modules/budget/versions.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.43, < 5.0"
+      version = ">= 4.5, < 5.0"
     }
   }
 

--- a/modules/gsuite_enabled/versions.tf
+++ b/modules/gsuite_enabled/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.50, < 5.0"
+      version = "~> 4.5"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 3.50, < 5.0"
+      version = "~> 4.5"
     }
     gsuite = {
       source  = "DeviaVir/gsuite"

--- a/modules/svpc_service_project/versions.tf
+++ b/modules/svpc_service_project/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.50, < 5.0"
+      version = "~> 4.5"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 3.50, < 5.0"
+      version = "~> 4.5"
     }
   }
   provider_meta "google" {

--- a/test/fixtures/full/main.tf
+++ b/test/fixtures/full/main.tf
@@ -40,7 +40,7 @@ locals {
 
 module "vpc" {
   source  = "terraform-google-modules/network/google"
-  version = "~> 2.0"
+  version = ">= 4.0.1, < 5.0"
 
   network_name = "pf-test-int-full-${var.random_string_for_testing}"
   project_id   = var.shared_vpc

--- a/test/fixtures/full/versions.tf
+++ b/test/fixtures/full/versions.tf
@@ -18,11 +18,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.30"
+      version = "~> 4.5"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.30"
+      version = "~> 4.5"
     }
     gsuite = {
       source  = "deviavir/gsuite"

--- a/test/fixtures/minimal/main.tf
+++ b/test/fixtures/minimal/main.tf
@@ -15,11 +15,11 @@
  */
 
 provider "google" {
-  version = "~> 3.30"
+  version = "~> 4.5"
 }
 
 provider "google-beta" {
-  version = "~> 3.30"
+  version = "~> 4.5"
 }
 
 provider "null" {

--- a/test/fixtures/shared_vpc_no_subnets/main.tf
+++ b/test/fixtures/shared_vpc_no_subnets/main.tf
@@ -15,11 +15,11 @@
  */
 
 provider "google" {
-  version = "~> 3.30"
+  version = "~> 4.5"
 }
 
 provider "google-beta" {
-  version = "~> 3.30"
+  version = "~> 4.5"
 }
 
 provider "gsuite" {

--- a/test/fixtures/vpc_sc_project/main.tf
+++ b/test/fixtures/vpc_sc_project/main.tf
@@ -15,11 +15,11 @@
  */
 
 provider "google" {
-  version = "~> 3.30"
+  version = "~> 4.5"
 }
 
 provider "google-beta" {
-  version = "~> 3.30"
+  version = "~> 4.5"
 }
 
 provider "null" {
@@ -36,6 +36,7 @@ locals {
 
 module "regular_service_perimeter_1" {
   source         = "terraform-google-modules/vpc-service-controls/google//modules/regular_service_perimeter"
+  version        = "~> 3.2"
   policy         = var.policy_id
   perimeter_name = local.perimeter_name
   description    = "New service perimeter"

--- a/test/fixtures/vpc_sc_project/main.tf
+++ b/test/fixtures/vpc_sc_project/main.tf
@@ -14,29 +14,12 @@
  * limitations under the License.
  */
 
-provider "google" {
-  version = "~> 4.5"
-}
-
-provider "google-beta" {
-  version = "~> 4.5"
-}
-
-provider "null" {
-  version = "~> 2.1"
-}
-
-provider "random" {
-  version = "~> 2.2"
-}
-
 locals {
   perimeter_name = "regular_service_perimeter_${var.random_string_for_testing}"
 }
 
 module "regular_service_perimeter_1" {
-  source         = "terraform-google-modules/vpc-service-controls/google//modules/regular_service_perimeter"
-  version        = "~> 3.2"
+  source         = "github.com/terraform-google-modules/terraform-google-vpc-service-controls//modules/regular_service_perimeter"
   policy         = var.policy_id
   perimeter_name = local.perimeter_name
   description    = "New service perimeter"

--- a/test/fixtures/vpc_sc_project/versions.tf
+++ b/test/fixtures/vpc_sc_project/versions.tf
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.5"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 4.5"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 2.1"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 2.2"
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -241,6 +241,16 @@ variable "budget_alert_spent_percents" {
   default     = [0.5, 0.7, 1.0]
 }
 
+variable "budget_labels" {
+  description = "A single label and value pair specifying that usage from only this set of labeled resources should be included in the budget."
+  type        = map(string)
+  default     = {}
+  validation {
+    condition     = length(var.budget_labels) <= 1
+    error_message = "Only 0 or 1 labels may be supplied for the budget filter."
+  }
+}
+
 variable "vpc_service_control_attach_enabled" {
   description = "Whether the project will be attached to a VPC Service Control Perimeter"
   type        = bool

--- a/versions.tf
+++ b/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.50, < 5.0"
+      version = "~> 4.5"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 3.50, < 5.0"
+      version = "~> 4.5"
     }
   }
   provider_meta "google" {


### PR DESCRIPTION
This PR adds the ability to support creating budgets that track spending filtered by labels on GCP resources. There is a single CI error that traces to a separate repo. The error will be revised once this PR is accepted (and maybe tagged as well):

https://github.com/terraform-google-modules/terraform-google-vpc-service-controls/pull/65