### PR TITLE
Handle compute.googleapis.com properly when passed in via activate_api_identities

### DIFF
--- a/modules/project_services/main.tf
+++ b/modules/project_services/main.tf
@@ -15,7 +15,8 @@
  */
 
 locals {
-  services = var.enable_apis ? toset(concat(var.activate_apis, [for i in var.activate_api_identities : i.api])) : toset([])
+  activate_compute_identity = 0 != length([for i in var.activate_api_identities : i if i.api == "compute.googleapis.com"])
+  services                  = var.enable_apis ? toset(concat(var.activate_apis, [for i in var.activate_api_identities : i.api])) : toset([])
   service_identities = flatten([
     for i in var.activate_api_identities : [
       for r in i.roles :
@@ -35,10 +36,12 @@ resource "google_project_service" "project_services" {
   disable_dependent_services = var.disable_dependent_services
 }
 
+# First handle all service identities EXCEPT compute.googleapis.com.
 resource "google_project_service_identity" "project_service_identities" {
   for_each = {
     for i in var.activate_api_identities :
     i.api => i
+    if i.api != "compute.googleapis.com"
   }
 
   provider = google-beta
@@ -46,13 +49,37 @@ resource "google_project_service_identity" "project_service_identities" {
   service  = each.value.api
 }
 
+# Process the compute.googleapis.com identity separately, if present in the inputs.
+data "google_compute_default_service_account" "default" {
+  count   = local.activate_compute_identity ? 1 : 0
+  project = var.project_id
+}
+
+locals {
+  add_service_roles = merge(
+    {
+      for si in local.service_identities :
+      "${si.api} ${si.role}" => {
+        email = google_project_service_identity.project_service_identities[si.api].email
+        role  = si.role
+      }
+      if si.api != "compute.googleapis.com"
+    },
+    {
+      for si in local.service_identities :
+      "${si.api} ${si.role}" => {
+        email = data.google_compute_default_service_account.default[0].email
+        role  = si.role
+      }
+      if si.api == "compute.googleapis.com"
+    }
+  )
+}
+
 resource "google_project_iam_member" "project_service_identity_roles" {
-  for_each = {
-    for si in local.service_identities :
-    "${si.api} ${si.role}" => si
-  }
+  for_each = local.add_service_roles
 
   project = var.project_id
   role    = each.value.role
-  member  = "serviceAccount:${google_project_service_identity.project_service_identities[each.value.api].email}"
+  member  = "serviceAccount:${each.value.email}"
 }


### PR DESCRIPTION
## Synopsis

Process roles for the compute.googleapis.com service identity separately from other service identities when passed via activate_api_identities.

## Details

This service identity cannot be created with the `google_project_service_identity` resource. Attempting to activate this service identity leads to an error response. It seems that this API call is not permitted despite lack of documentation. This can be seen by calling:

```sh
gcloud alpha services identity create --service=compute.googleapis.com --log-http
```

Calling this same command with, e.g., cloudbuild.googleapis.com does not result in an error.

It seems the service is activated by default, so instead just retrieve the email using `google_compute_default_service_account`. So get this email, create a combined map with this service identity (if present) and other service identities (if present), and then process this map as before, adding each role for each service identity.