### PR TITLE
chore: release 11.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Extending the adopted spec, each change should have a link to its corresponding pull request appended.
 
+### [11.2.2](https://www.github.com/terraform-google-modules/terraform-google-project-factory/compare/v11.2.1...v11.2.2) (2021-10-13)
+
+
+### Bug Fixes
+
+* Allow explicit provider configuration in module ([#624](https://www.github.com/terraform-google-modules/terraform-google-project-factory/issues/624)) ([621c527](https://www.github.com/terraform-google-modules/terraform-google-project-factory/commit/621c5275527a0d392a842bd71e7ad88e2eba1835))
+* billing_budget resource should use GA provider ([#626](https://www.github.com/terraform-google-modules/terraform-google-project-factory/issues/626)) ([b6d7bf1](https://www.github.com/terraform-google-modules/terraform-google-project-factory/commit/b6d7bf1af2062e557b3fb2c883879554e10d7702))
+* Don't attempt to activate service identity for compute.googleapis.com ([#628](https://www.github.com/terraform-google-modules/terraform-google-project-factory/issues/628)) ([777092c](https://www.github.com/terraform-google-modules/terraform-google-project-factory/commit/777092c279ef3f4f5115a04c8d195a778e94514a))
+
 ### [11.2.1](https://www.github.com/terraform-google-modules/terraform-google-project-factory/compare/v11.2.0...v11.2.1) (2021-09-23)
 
 

--- a/modules/budget/versions.tf
+++ b/modules/budget/versions.tf
@@ -25,9 +25,9 @@ terraform {
   }
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/terraform-google-project-factory:budget/v11.2.1"
+    module_name = "blueprints/terraform/terraform-google-project-factory:budget/v11.2.2"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/terraform-google-project-factory:budget/v11.2.1"
+    module_name = "blueprints/terraform/terraform-google-project-factory:budget/v11.2.2"
   }
 }

--- a/modules/fabric-project/versions.tf
+++ b/modules/fabric-project/versions.tf
@@ -24,9 +24,9 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/terraform-google-project-factory:fabric-project/v11.2.1"
+    module_name = "blueprints/terraform/terraform-google-project-factory:fabric-project/v11.2.2"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/terraform-google-project-factory:fabric-project/v11.2.1"
+    module_name = "blueprints/terraform/terraform-google-project-factory:fabric-project/v11.2.2"
   }
 }

--- a/modules/gsuite_enabled/versions.tf
+++ b/modules/gsuite_enabled/versions.tf
@@ -31,9 +31,9 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/terraform-google-project-factory:gsuite_enabled/v11.2.1"
+    module_name = "blueprints/terraform/terraform-google-project-factory:gsuite_enabled/v11.2.2"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/terraform-google-project-factory:gsuite_enabled/v11.2.1"
+    module_name = "blueprints/terraform/terraform-google-project-factory:gsuite_enabled/v11.2.2"
   }
 }

--- a/modules/project_services/versions.tf
+++ b/modules/project_services/versions.tf
@@ -27,9 +27,9 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/terraform-google-project-factory:project_services/v11.2.1"
+    module_name = "blueprints/terraform/terraform-google-project-factory:project_services/v11.2.2"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/terraform-google-project-factory:project_services/v11.2.1"
+    module_name = "blueprints/terraform/terraform-google-project-factory:project_services/v11.2.2"
   }
 }

--- a/modules/shared_vpc_access/versions.tf
+++ b/modules/shared_vpc_access/versions.tf
@@ -27,9 +27,9 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/terraform-google-project-factory:shared_vpc_access/v11.2.1"
+    module_name = "blueprints/terraform/terraform-google-project-factory:shared_vpc_access/v11.2.2"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/terraform-google-project-factory:shared_vpc_access/v11.2.1"
+    module_name = "blueprints/terraform/terraform-google-project-factory:shared_vpc_access/v11.2.2"
   }
 }

--- a/modules/svpc_service_project/versions.tf
+++ b/modules/svpc_service_project/versions.tf
@@ -27,9 +27,9 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/terraform-google-project-factory:svpc_service_project/v11.2.1"
+    module_name = "blueprints/terraform/terraform-google-project-factory:svpc_service_project/v11.2.2"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/terraform-google-project-factory:svpc_service_project/v11.2.1"
+    module_name = "blueprints/terraform/terraform-google-project-factory:svpc_service_project/v11.2.2"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -27,9 +27,9 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/terraform-google-project-factory/v11.2.1"
+    module_name = "blueprints/terraform/terraform-google-project-factory/v11.2.2"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/terraform-google-project-factory/v11.2.1"
+    module_name = "blueprints/terraform/terraform-google-project-factory/v11.2.2"
   }
 }


### PR DESCRIPTION
There is a behavior change with latest releases, project-service-account being added to shared-vpc project irrespective of "grant_services_network_role = false"