### PR TITLE
Update required_providers after change in b6d7bf1

### DIFF
--- a/modules/budget/versions.tf
+++ b/modules/budget/versions.tf
@@ -18,8 +18,8 @@ terraform {
   required_version = ">= 0.13"
 
   required_providers {
-    google-beta = {
-      source  = "hashicorp/google-beta"
+    google = {
+      source  = "hashicorp/google"
       version = ">= 3.43, < 4.0"
     }
   }


### PR DESCRIPTION
#626 should have included an update to the `required_providers`. Without this, a terraform root module that makes use of this module will not know that it needs to download the GA `google` provider during `terraform init`.

Additionally, #626 broke the ability to successfully pass a provider because they no longer match the correct type. For example, this in 11.2.1

```hcl
  providers = {
    google-beta = google-beta.budget
  }
```

will not continue to work even if you modify it to something like

```hcl
  providers = {
    google = google-beta.budget
  }
```

because the correct type of provider (`google`) is not being passed. The Billing Budget API prohibits end user credentials for authentication for a number of actions so this ability is somewhat important in the module.