### PR TITLE
Plassen wip forecasted billing alert

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -93,7 +93,7 @@ module "budget" {
   billing_account                  = var.billing_account
   amount                           = var.budget_amount
   alert_spent_percents             = var.budget_alert_spent_percents
-  alert_spend_basis		   = var.budget_alert_spend_basis
+  alert_spend_basis                = var.budget_alert_spend_basis
   alert_pubsub_topic               = var.budget_alert_pubsub_topic
   monitoring_notification_channels = var.budget_monitoring_notification_channels
   display_name                     = var.budget_display_name != null ? var.budget_display_name : null

--- a/main.tf
+++ b/main.tf
@@ -93,6 +93,7 @@ module "budget" {
   billing_account                  = var.billing_account
   amount                           = var.budget_amount
   alert_spent_percents             = var.budget_alert_spent_percents
+  alert_spend_basis		   = var.budget_alert_spend_basis
   alert_pubsub_topic               = var.budget_alert_pubsub_topic
   monitoring_notification_channels = var.budget_monitoring_notification_channels
   display_name                     = var.budget_display_name != null ? var.budget_display_name : null

--- a/modules/budget/main.tf
+++ b/modules/budget/main.tf
@@ -57,6 +57,7 @@ resource "google_billing_budget" "budget" {
     for_each = var.alert_spent_percents
     content {
       threshold_percent = threshold_rules.value
+      spend_basis	= var.alert_spend_basis
     }
   }
 

--- a/modules/budget/variables.tf
+++ b/modules/budget/variables.tf
@@ -59,6 +59,12 @@ variable "alert_spent_percents" {
   default     = [0.5, 0.7, 1.0]
 }
 
+variable "alert_spend_basis" {
+  description = "The type of basis used to determine if spend has passed the threshold"
+  type        = string
+  default     = "CURRENT_SPEND"
+}
+
 variable "alert_pubsub_topic" {
   description = "The name of the Cloud Pub/Sub topic where budget related messages will be published, in the form of `projects/{project_id}/topics/{topic_id}`"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -241,6 +241,12 @@ variable "budget_alert_spent_percents" {
   default     = [0.5, 0.7, 1.0]
 }
 
+variable "budget_alert_spend_basis" {
+  description = "The type of basis used to determine if spend has passed the threshold."
+  type        = string
+  default     = "CURRENT_SPEND"
+}
+
 variable "vpc_service_control_attach_enabled" {
   description = "Whether the project will be attached to a VPC Service Control Perimeter"
   type        = bool


### PR DESCRIPTION
Added optional argument "spend_basis" to the budget module alert configuration, in order to allow alerts be defined on a forecast basis, which, can provide a better early warning.

Cheers