### PR TITLE
BUG #690 Fix - VPC-SC SA destroy sequence

### DIFF
--- a/modules/core_project_factory/main.tf
+++ b/modules/core_project_factory/main.tf
@@ -338,6 +338,7 @@ resource "google_storage_bucket_iam_member" "api_s_account_storage_admin_on_proj
  *****************************************/
 resource "google_access_context_manager_service_perimeter_resource" "service_perimeter_attachment" {
   count          = var.vpc_service_control_attach_enabled ? 1 : 0
+  depends_on     = [google_service_account.default_service_account]
   perimeter_name = var.vpc_service_control_perimeter_name
   resource       = "projects/${google_project.main.number}"
 }


### PR DESCRIPTION
Setting "depends_on" will execute the correct destroy sequence required for the **VPC-SC Perimeter Resource attachment** and the **Default Service Account**
[Issue 690](https://github.com/terraform-google-modules/terraform-google-project-factory/issues/690)