### PR TITLE
fix: use module release rather than repo head

### DIFF
--- a/test/fixtures/vpc_sc_project/main.tf
+++ b/test/fixtures/vpc_sc_project/main.tf
@@ -19,7 +19,8 @@ locals {
 }
 
 module "regular_service_perimeter_1" {
-  source         = "github.com/terraform-google-modules/terraform-google-vpc-service-controls//modules/regular_service_perimeter"
+  source         = "terraform-google-modules/vpc-service-controls/google//modules/regular_service_perimeter"
+  version        = "~> 4.0"
   policy         = var.policy_id
   perimeter_name = local.perimeter_name
   description    = "New service perimeter"


### PR DESCRIPTION
Use the Access Perimeter Submodule's release rather than the repo's head in test.  #685 