### PR TITLE
fix: add serviceusage API to fabric-project enable default list

### DIFF
--- a/examples/fabric_project/README.md
+++ b/examples/fabric_project/README.md
@@ -7,7 +7,7 @@ This example illustrates how to create a simple project using the `fabric-projec
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| activate\_apis | Service APIs to enable. | `list(string)` | <pre>[<br>  "compute.googleapis.com"<br>]</pre> | no |
+| activate\_apis | Service APIs to enable. | `list(string)` | <pre>[<br>  "serviceusage.googleapis.com",<br>  "compute.googleapis.com"<br>]</pre> | no |
 | billing\_account | Billing account id. | `string` | n/a | yes |
 | name | Project name, joined with prefix. | `string` | `"fabric-project"` | no |
 | owners | Optional list of IAM-format members to set as project owners. | `list(string)` | `[]` | no |

--- a/examples/fabric_project/variables.tf
+++ b/examples/fabric_project/variables.tf
@@ -17,7 +17,7 @@
 variable "activate_apis" {
   description = "Service APIs to enable."
   type        = list(string)
-  default     = ["compute.googleapis.com"]
+  default     = ["serviceusage.googleapis.com", "compute.googleapis.com"]
 }
 
 variable "billing_account" {


### PR DESCRIPTION
fix: add serviceusage.googleapis.com to default list of APIs to enable in fabric-project

Closes #710 