### PR TITLE
fix!: test/setup/outputs.folder_id returns folder_id

### DIFF
--- a/examples/project-hierarchy/main.tf
+++ b/examples/project-hierarchy/main.tf
@@ -37,7 +37,7 @@ module "project-prod-gke" {
   name              = "hierarchy-sample-prod-gke"
   org_id            = var.organization_id
   billing_account   = var.billing_account
-  folder_id         = google_folder.prod.id
+  folder_id         = google_folder.prod.folder_id
 }
 
 module "project-factory" {
@@ -46,5 +46,5 @@ module "project-factory" {
   name              = "hierarchy-sample-factory"
   org_id            = var.organization_id
   billing_account   = var.billing_account
-  folder_id         = google_folder.prod.id
+  folder_id         = google_folder.prod.folder_id
 }

--- a/test/fixtures/fabric_project/main.tf
+++ b/test/fixtures/fabric_project/main.tf
@@ -18,7 +18,7 @@ module "fabric-project" {
   source = "../../../examples/fabric_project"
 
   name            = "fabric-project"
-  parent          = var.folder_id
+  parent          = "folders/${var.folder_id}"
   billing_account = var.billing_account
   activate_apis = [
     "compute.googleapis.com",

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -30,7 +30,7 @@ module "pfactory_project" {
   name              = "ci-pfactory-tests"
   random_project_id = true
   org_id            = var.org_id
-  folder_id         = google_folder.ci_pfactory_folder.id
+  folder_id         = google_folder.ci_pfactory_folder.folder_id
   billing_account   = var.billing_account
 
   activate_apis = [

--- a/test/setup/outputs.tf
+++ b/test/setup/outputs.tf
@@ -28,7 +28,7 @@ output "sa_key" {
 }
 
 output "folder_id" {
-  value = google_folder.ci_pfactory_folder.id
+  value = google_folder.ci_pfactory_folder.folder_id
 }
 
 output "org_id" {


### PR DESCRIPTION
fix!: test/setup/outputs.folder_id returns `folder_id` instead of `folders/{folder_id}`

Closes #711 