### PR TITLE
fix: add cloudresourcemanager api to examples

### DIFF
--- a/examples/budget_project/main.tf
+++ b/examples/budget_project/main.tf
@@ -28,6 +28,12 @@ module "budget_project" {
   folder_id         = var.folder_id
   billing_account   = var.billing_account
   budget_amount     = var.budget_amount
+
+  activate_apis = [
+    "compute.googleapis.com",
+    "cloudresourcemanager.googleapis.com"
+  ]
+
 }
 
 

--- a/examples/essential_contacts/main.tf
+++ b/examples/essential_contacts/main.tf
@@ -26,7 +26,8 @@ module "project-factory" {
   activate_apis = [
     "compute.googleapis.com",
     "container.googleapis.com",
-    "essentialcontacts.googleapis.com"
+    "essentialcontacts.googleapis.com",
+    "serviceusage.googleapis.com"
   ]
 
   essential_contacts = {

--- a/examples/shared_vpc/main.tf
+++ b/examples/shared_vpc/main.tf
@@ -31,6 +31,12 @@ module "host-project" {
   billing_account                = var.billing_account
   enable_shared_vpc_host_project = true
   default_network_tier           = var.default_network_tier
+
+  activate_apis = [
+    "compute.googleapis.com",
+    "cloudresourcemanager.googleapis.com"
+  ]
+
 }
 
 /******************************************

--- a/test/fixtures/vpc_sc_project/main.tf
+++ b/test/fixtures/vpc_sc_project/main.tf
@@ -41,7 +41,8 @@ module "project-factory" {
   activate_apis = [
     "compute.googleapis.com",
     "accesscontextmanager.googleapis.com",
-    "storage-component.googleapis.com"
+    "storage-component.googleapis.com",
+    "cloudresourcemanager.googleapis.com"
   ]
 
   default_service_account     = "DISABLE"


### PR DESCRIPTION
- Add activation of cloudresourcemanager API to budget_projects example. Closes #715 
- Add activation of cloudresourcemanager API to shared_vpc example. Closes #717 
- Add activation of serviceusage API to essential_contacts example. Closes #718 
- Add activation of cloudresourcemanager API to vpc_sc_project example. Closes #719