### PR TITLE
chore: add billingbudgets API to budget

### DIFF
--- a/examples/budget_project/main.tf
+++ b/examples/budget_project/main.tf
@@ -31,7 +31,8 @@ module "budget_project" {
 
   activate_apis = [
     "compute.googleapis.com",
-    "cloudresourcemanager.googleapis.com"
+    "cloudresourcemanager.googleapis.com",
+    "billingbudgets.googleapis.com"
   ]
 
 }


### PR DESCRIPTION
- add billingbudgets API to budget example. Fixes #720 