### PR TITLE
feat: add deploymentmanager.googleapis.com to supported apis

### DIFF
--- a/modules/shared_vpc_access/main.tf
+++ b/modules/shared_vpc_access/main.tf
@@ -27,6 +27,7 @@ locals {
     "dataflow.googleapis.com" : format("service-%s@dataflow-service-producer-prod.iam.gserviceaccount.com", local.service_project_number),
     "composer.googleapis.com" : format("service-%s@cloudcomposer-accounts.iam.gserviceaccount.com", local.service_project_number)
     "vpcaccess.googleapis.com" : format("service-%s@gcp-sa-vpcaccess.iam.gserviceaccount.com", local.service_project_number)
+    "deploymentmanager.googleapis.com" : format("%s@cloudservices.gserviceaccount.com", local.service_project_number)
   }
   gke_shared_vpc_enabled      = contains(var.active_apis, "container.googleapis.com")
   composer_shared_vpc_enabled = contains(var.active_apis, "composer.googleapis.com")


### PR DESCRIPTION
This adds the deployment manager-api to the supported apis.

This is mandatory for using GKE in a shared vpc-subnet when the nodes are getting deployed.

Example-Output:
```
Google Compute Engine: Not all instances running in IGM after 14.50192001s.
Expected 1, running 0, transitioning 1. Current errors:
[PERMISSIONS_ERROR]: Instance '<GKE-NODE-POOL-ID>' creation failed:
Required 'compute.subnetworks.use' permission for 'projects/<NETWORK-HOST-PROJECT-ID>/regions/<SUBNET-REGION>/subnetworks/<SUBNET-ID>'
(when acting as '<SERVICE-PROJECT-NUMBER>@cloudservices.gserviceaccount.com').
```
