### PR TITLE
feat: add random_project_id_length

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ determining that location is as follows:
 | org\_id | The organization ID. | `string` | n/a | yes |
 | project\_id | The ID to give the project. If not provided, the `name` will be used. | `string` | `""` | no |
 | project\_sa\_name | Default service account name for the project. | `string` | `"project-service-account"` | no |
-| random\_project\_id | Adds a suffix of 4 random characters to the `project_id` | `bool` | `false` | no |
+| random\_project\_id | Adds a suffix of 4 random characters to the `project_id`. | `bool` | `false` | no |
+| random\_project\_id\_length | Sets the length of `random_project_id` to the provided length, and uses a `random_string` for a larger collusion domain.  Recommended for use with CI. | `number` | `null` | no |
 | sa\_role | A role to give the default Service Account for the project (defaults to none) | `string` | `""` | no |
 | shared\_vpc\_subnets | List of subnets fully qualified subnet IDs (ie. projects/$project\_id/regions/$region/subnetworks/$subnet\_id) | `list(string)` | `[]` | no |
 | svpc\_host\_project\_id | The ID of the host project which hosts the shared VPC | `string` | `""` | no |

--- a/examples/budget_project/main.tf
+++ b/examples/budget_project/main.tf
@@ -21,13 +21,14 @@ resource "random_string" "suffix" {
 }
 
 module "budget_project" {
-  source            = "../../"
-  name              = "budget-project-${random_string.suffix.result}"
-  random_project_id = true
-  org_id            = var.org_id
-  folder_id         = var.folder_id
-  billing_account   = var.billing_account
-  budget_amount     = var.budget_amount
+  source                   = "../../"
+  name                     = "budget-project-${random_string.suffix.result}"
+  random_project_id        = true
+  random_project_id_length = 6
+  org_id                   = var.org_id
+  folder_id                = var.folder_id
+  billing_account          = var.billing_account
+  budget_amount            = var.budget_amount
 
   activate_apis = [
     "compute.googleapis.com",

--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,7 @@ module "project-factory" {
   lien                               = var.lien
   manage_group                       = var.group_name != "" ? true : false
   random_project_id                  = var.random_project_id
+  random_project_id_length           = var.random_project_id_length
   org_id                             = var.org_id
   name                               = var.name
   project_id                         = var.project_id

--- a/modules/core_project_factory/main.tf
+++ b/modules/core_project_factory/main.tf
@@ -21,10 +21,18 @@ resource "random_id" "random_project_id_suffix" {
   byte_length = 2
 }
 
+resource "random_string" "random_project_id_suffix" {
+  count   = local.use_random_string ? 1 : 0
+  length  = var.random_project_id_length
+  special = false
+  upper   = false
+}
+
 /******************************************
   Locals configuration
  *****************************************/
 locals {
+  use_random_string = try(var.random_project_id_length > 0, false)
   group_id          = var.manage_group ? format("group:%s", var.group_email) : ""
   base_project_id   = var.project_id == "" ? var.name : var.project_id
   project_org_id    = var.folder_id != "" ? null : var.org_id
@@ -32,7 +40,7 @@ locals {
   temp_project_id = var.random_project_id ? format(
     "%s-%s",
     local.base_project_id,
-    random_id.random_project_id_suffix.hex,
+    local.use_random_string ? random_string.random_project_id_suffix[0].result : random_id.random_project_id_suffix.hex,
   ) : local.base_project_id
   s_account_fmt = var.create_project_sa ? format(
     "serviceAccount:%s",

--- a/modules/core_project_factory/variables.tf
+++ b/modules/core_project_factory/variables.tf
@@ -45,9 +45,15 @@ variable "project_id" {
 }
 
 variable "random_project_id" {
-  description = "Adds a suffix of 4 random characters to the `project_id`"
+  description = "Adds a suffix of 4 random characters to the `project_id`."
   type        = bool
   default     = false
+}
+
+variable "random_project_id_length" {
+  description = "Sets the length of `random_project_id` to the provided length, and uses a `random_string` for a larger collusion domain.  Recommended for use with CI."
+  type        = number
+  default     = null
 }
 
 variable "org_id" {

--- a/test/integration/budget/controls/budget.rb
+++ b/test/integration/budget/controls/budget.rb
@@ -38,7 +38,7 @@ control "project-factory-budget-project" do
       end
     end
 
-    it { expect(metadata).to include(name: project_id[0...-5]) }
+    it { expect(metadata).to include(name: project_id[0...-7]) }
     it { expect(metadata).to include(projectId: project_id) }
   end
 end

--- a/variables.tf
+++ b/variables.tf
@@ -15,9 +15,15 @@
  */
 
 variable "random_project_id" {
-  description = "Adds a suffix of 4 random characters to the `project_id`"
+  description = "Adds a suffix of 4 random characters to the `project_id`."
   type        = bool
   default     = false
+}
+
+variable "random_project_id_length" {
+  description = "Sets the length of `random_project_id` to the provided length, and uses a `random_string` for a larger collusion domain.  Recommended for use with CI."
+  type        = number
+  default     = null
 }
 
 variable "org_id" {


### PR DESCRIPTION
* Add `random_project_id_length` which also enables a larger collusion domain from [0-9a-f]4 to [0-9a-z]n.