### PR TITLE
Add support to project cloud storage public access prevention

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ determining that location is as follows:
 | bucket\_labels | A map of key/value label pairs to assign to the bucket (optional) | `map(string)` | `{}` | no |
 | bucket\_location | The location for a GCS bucket to create (optional) | `string` | `"US"` | no |
 | bucket\_name | A name for a GCS bucket to create (in the bucket\_project project), useful for Terraform state (optional) | `string` | `""` | no |
+| bucket\_pap | Enable Public Access Prevention. Possible values are "enforced" or "inherited". | `string` | `"inherited"` | no |
 | bucket\_project | A project to create a GCS bucket (bucket\_name) in, useful for Terraform state (optional) | `string` | `""` | no |
 | bucket\_ula | Enable Uniform Bucket Level Access | `bool` | `true` | no |
 | bucket\_versioning | Enable versioning for a GCS bucket to create (optional) | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -58,6 +58,7 @@ module "project-factory" {
   bucket_labels                      = var.bucket_labels
   bucket_force_destroy               = var.bucket_force_destroy
   bucket_ula                         = var.bucket_ula
+  bucket_pap                         = var.bucket_pap
   auto_create_network                = var.auto_create_network
   disable_services_on_destroy        = var.disable_services_on_destroy
   default_service_account            = var.default_service_account

--- a/modules/core_project_factory/main.tf
+++ b/modules/core_project_factory/main.tf
@@ -282,6 +282,8 @@ resource "google_project_usage_export_bucket" "usage_report_export" {
   Project's bucket creation
  ***********************************************/
 resource "google_storage_bucket" "project_bucket" {
+  provider = google-beta
+
   count = local.create_bucket ? 1 : 0
 
   name                        = local.project_bucket_name
@@ -290,6 +292,7 @@ resource "google_storage_bucket" "project_bucket" {
   labels                      = var.bucket_labels
   force_destroy               = var.bucket_force_destroy
   uniform_bucket_level_access = var.bucket_ula
+  public_access_prevention    = var.bucket_pap
 
   versioning {
     enabled = var.bucket_versioning

--- a/modules/core_project_factory/variables.tf
+++ b/modules/core_project_factory/variables.tf
@@ -181,6 +181,12 @@ variable "bucket_ula" {
   default     = true
 }
 
+variable "bucket_pap" {
+  description = "Enable Public Access Prevention. Possible values are \"enforced\" or \"inherited\"."
+  type        = string
+  default     = "inherited"
+}
+
 variable "auto_create_network" {
   description = "Create the default network"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -181,6 +181,12 @@ variable "bucket_ula" {
   default     = true
 }
 
+variable "bucket_pap" {
+  description = "Enable Public Access Prevention. Possible values are \"enforced\" or \"inherited\"."
+  type        = string
+  default     = "inherited"
+}
+
 variable "auto_create_network" {
   description = "Create the default network"
   type        = bool


### PR DESCRIPTION
Add support to project cloud storage public access prevention
    
New variable: bucket_pap
possible values: "enforced" or "inherited" (default)

public access prevention support implemented by PR https://github.com/hashicorp/terraform-provider-google-beta/pull/3919, but missing associated documentation as mentioned in the link. Also only in google-beta, although PAP is no longer beta.