### PR TITLE
Configure propagation time (time sleep) for inclusion of the created project in a VPC-SC perimeter

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ determining that location is as follows:
 | usage\_bucket\_prefix | Prefix in the GCS bucket to store GCE usage reports in (optional) | `string` | `""` | no |
 | vpc\_service\_control\_attach\_enabled | Whether the project will be attached to a VPC Service Control Perimeter | `bool` | `false` | no |
 | vpc\_service\_control\_perimeter\_name | The name of a VPC Service Control Perimeter to add the created project to | `string` | `null` | no |
+| vpc\_service\_control\_sleep\_duration | The duration to sleep in seconds before adding the project to a shared VPC after the project is added to the VPC Service Control Perimeter | `string` | `"5s"` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -66,6 +66,7 @@ module "project-factory" {
   disable_dependent_services         = var.disable_dependent_services
   vpc_service_control_attach_enabled = var.vpc_service_control_attach_enabled
   vpc_service_control_perimeter_name = var.vpc_service_control_perimeter_name
+  vpc_service_control_sleep_duration = var.vpc_service_control_sleep_duration
   default_network_tier               = var.default_network_tier
 }
 

--- a/modules/core_project_factory/main.tf
+++ b/modules/core_project_factory/main.tf
@@ -108,10 +108,10 @@ module "project_services" {
 /******************************************
   Shared VPC configuration
  *****************************************/
-resource "time_sleep" "wait_5_seconds" {
+resource "time_sleep" "wait_vpc_sc_propagation" {
   count           = var.vpc_service_control_attach_enabled ? 1 : 0
   depends_on      = [google_access_context_manager_service_perimeter_resource.service_perimeter_attachment[0], google_project_service.enable_access_context_manager[0]]
-  create_duration = "5s"
+  create_duration = var.vpc_service_control_sleep_duration
 }
 
 resource "google_compute_shared_vpc_service_project" "shared_vpc_attachment" {
@@ -120,7 +120,7 @@ resource "google_compute_shared_vpc_service_project" "shared_vpc_attachment" {
   count           = var.enable_shared_vpc_service_project ? 1 : 0
   host_project    = var.shared_vpc
   service_project = google_project.main.project_id
-  depends_on      = [time_sleep.wait_5_seconds[0], module.project_services]
+  depends_on      = [time_sleep.wait_vpc_sc_propagation[0], module.project_services]
 }
 
 resource "google_compute_shared_vpc_host_project" "shared_vpc_host" {

--- a/modules/core_project_factory/variables.tf
+++ b/modules/core_project_factory/variables.tf
@@ -240,6 +240,12 @@ variable "vpc_service_control_perimeter_name" {
   default     = null
 }
 
+variable "vpc_service_control_sleep_duration" {
+  description = "The duration to sleep in seconds before adding the project to a shared VPC after the project is added to the VPC Service Control Perimeter"
+  type        = string
+  default     = "5s"
+}
+
 variable "default_network_tier" {
   description = "Default Network Service Tier for resources created in this project. If unset, the value will not be modified. See https://cloud.google.com/network-tiers/docs/using-network-service-tiers and https://cloud.google.com/network-tiers."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -299,6 +299,12 @@ variable "vpc_service_control_perimeter_name" {
   default     = null
 }
 
+variable "vpc_service_control_sleep_duration" {
+  description = "The duration to sleep in seconds before adding the project to a shared VPC after the project is added to the VPC Service Control Perimeter"
+  type        = string
+  default     = "5s"
+}
+
 variable "grant_services_security_admin_role" {
   description = "Whether or not to grant Kubernetes Engine Service Agent the Security Admin role on the host project so it can manage firewall rules"
   type        = bool


### PR DESCRIPTION
Configure the propagation time (time sleep) to be used between the inclusion of the project create in the VPC-SC perimeter and the inclusion of the project create in the shared VPC.

This change is needed  if the API `compute.googleapis.com` is in the list of restricted services of the VPC-SC perimeter