### PR TITLE
fix: removes policy id env var from int build config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,12 +81,6 @@ export TF_VAR_folder_id="your_folder_id"
 export TF_VAR_billing_account="your_billing_account_id"
 export TF_VAR_gsuite_admin_email="your_gsuite_admin_email"
 export TF_VAR_gsuite_domain="your_gsuite_domain"
-export TF_VAR_policy_id="your_access_context_manager_policy_id"
-```
-
-you can find Access Context Manager policy ID by executing following command
-```bash
-gcloud access-context-manager policies list --organization="your_org_id"
 ```
 
 With these settings in place, you can prepare the test setup using Docker:

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.8
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 
@@ -32,7 +32,6 @@ docker_run:
 		-e TF_VAR_billing_account \
 		-e TF_VAR_gsuite_admin_email \
 		-e TF_VAR_gsuite_domain \
-		-e TF_VAR_policy_id \
 		-v "${CURDIR}":/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
 		/bin/bash
@@ -47,7 +46,6 @@ docker_test_prepare:
 		-e TF_VAR_billing_account \
 		-e TF_VAR_gsuite_admin_email \
 		-e TF_VAR_gsuite_domain \
-		-e TF_VAR_policy_id \
 		-v "${CURDIR}":/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
 		/usr/local/bin/execute_with_credentials.sh prepare_environment
@@ -62,7 +60,6 @@ docker_test_cleanup:
 		-e TF_VAR_billing_account \
 		-e TF_VAR_gsuite_admin_email \
 		-e TF_VAR_gsuite_domain \
-		-e TF_VAR_policy_id \
 		-v "${CURDIR}":/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
 		/usr/local/bin/execute_with_credentials.sh cleanup_environment
@@ -77,7 +74,6 @@ docker_test_integration:
 		-e TF_VAR_billing_account \
 		-e TF_VAR_gsuite_admin_email \
 		-e TF_VAR_gsuite_domain \
-		-e TF_VAR_policy_id \
 		-v "${CURDIR}":/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
 		/usr/local/bin/test_integration.sh

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -175,4 +175,3 @@ options:
     - 'TF_VAR_gsuite_admin_email=project-factory-test-admin@test.infra.cft.tips'
     - 'TF_VAR_gsuite_domain=test.infra.cft.tips'
     - 'TF_VAR_domain=test.infra.cft.tips.'
-    - 'TF_VAR_policy_id=$_POLICY_ID'

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -165,7 +165,7 @@ tags:
 - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1.8'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1'
 options:
   machineType: 'N1_HIGHCPU_8'
   env:

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -21,4 +21,4 @@ tags:
 - 'lint'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1.8'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1'

--- a/test/setup/outputs.tf
+++ b/test/setup/outputs.tf
@@ -58,7 +58,3 @@ output "group_name" {
 output "service_account_email" {
   value = google_service_account.int_test.email
 }
-
-output "policy_id" {
-  value = var.policy_id
-}

--- a/test/setup/variables.tf
+++ b/test/setup/variables.tf
@@ -33,8 +33,3 @@ variable "gsuite_admin_email" {
 variable "gsuite_domain" {
   description = "Gsuite domain"
 }
-
-variable "policy_id" {
-  type        = string
-  description = "The ID of the access context manager policy the perimeter lies in"
-}


### PR DESCRIPTION
This is a partial rollback of: #788.

The reason #780 was failing was due to lack of permissions for the cloudbuild service agent on the test org. Giving that SA access context reader permission [fixes](https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/pull/1420) this.