### PR TITLE
Add missing output entry

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -64,6 +64,11 @@ output "service_account_unique_id" {
   description = "The unique id of the default service account"
 }
 
+output "project_bucket_name" {
+  description = "The name of the projec's bucket"
+  value       = google_storage_bucket.project_bucket.*.name
+}
+
 output "project_bucket_self_link" {
   value       = module.project-factory.project_bucket_self_link
   description = "Project's bucket selfLink"


### PR DESCRIPTION
Adding missing output. Exists in core module but not in this main one.

For reference: https://github.com/terraform-google-modules/terraform-google-project-factory/blob/master/modules/core_project_factory/outputs.tf#L64