### PR TITLE
feat(budget): Only read project data when budget will be created

### DIFF
--- a/examples/gke_shared_vpc/README.md
+++ b/examples/gke_shared_vpc/README.md
@@ -36,6 +36,6 @@ More information about GKE with Shared VPC can be found here: https://cloud.goog
 
 ## Outputs
 
-No output.
+No outputs.
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/budget/main.tf
+++ b/modules/budget/main.tf
@@ -34,7 +34,7 @@ locals {
 
 data "google_project" "project" {
   depends_on = [var.projects]
-  count      = length(var.projects)
+  count      = var.create_budget ? length(var.projects) : 0
   project_id = element(var.projects, count.index)
 }
 


### PR DESCRIPTION
When having a lot of projects the data resource makes the plan hard to read. To fix that only read the project data if it is needed.