### PR TITLE
fix: shared_vpc_access - Grant workstations.googleapi.com SA the networkUser role

### DIFF
--- a/modules/shared_vpc_access/main.tf
+++ b/modules/shared_vpc_access/main.tf
@@ -29,6 +29,7 @@ locals {
     "vpcaccess.googleapis.com" : format("service-%s@gcp-sa-vpcaccess.iam.gserviceaccount.com", local.service_project_number)
     "datastream.googleapis.com" : format("service-%s@gcp-sa-datastream.iam.gserviceaccount.com", local.service_project_number)
     "notebooks.googleapis.com" : format("service-%s@gcp-sa-notebooks.iam.gserviceaccount.com", local.service_project_number)
+    "workstations.googleapis.com" : format(" service-%s@gcp-sa-workstations.iam.gserviceaccount.com", local.service_project_number)
   }
   gke_shared_vpc_enabled        = contains(var.active_apis, "container.googleapis.com")
   composer_shared_vpc_enabled   = contains(var.active_apis, "composer.googleapis.com")
@@ -46,6 +47,7 @@ locals {
   if "dataflow.googleapis.com" compute.networkUser role granted to dataflow  service account for Dataflow on shared VPC subnets
   if "composer.googleapis.com" compute.networkUser role granted to composer service account for Composer on shared VPC subnets
   if "notebooks.googleapis.com" compute.networkUser role granted to notebooks service account for Notebooks on shared VPC Project
+  if "workstations.googleapis.com" compute.networkUser role granted to workstations service account for Workstations on shared VPC Project
   See: https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc
        https://cloud.google.com/dataflow/docs/concepts/security-and-permissions#cloud_dataflow_service_account
        https://cloud.google.com/composer/docs/how-to/managing/configuring-shared-vpc
@@ -100,6 +102,7 @@ resource "google_compute_subnetwork_iam_member" "cloudservices_shared_vpc_subnet
  if "dataflow.googleapis.com" compute.networkUser role granted to dataflow service account for Dataflow on shared VPC Project if no subnets defined
  if "composer.googleapis.com" compute.networkUser role granted to composer service account for Composer on shared VPC Project if no subnets defined
  if "notebooks.googleapis.com" compute.networkUser role granted to notebooks service account for Notebooks on shared VPC Project if no subnets defined
+ if "workstations.googleapis.com" compute.networkUser role granted to workstations service account for Workstations on shared VPC Project if no subnets defined
  *****************************************/
 resource "google_project_iam_member" "service_shared_vpc_user" {
   for_each = (length(var.shared_vpc_subnets) == 0) && var.enable_shared_vpc_service_project && var.grant_network_role ? toset(local.active_apis) : []


### PR DESCRIPTION
Update the shared_vpc_access module to grant the workstations.googleapis.com SA the appropriate network roles. It needs roles/compute.networkUser on the subnets being shared.