### PR TITLE
feat: Allow multiple quotas for the same metric

### DIFF
--- a/modules/quota_manager/main.tf
+++ b/modules/quota_manager/main.tf
@@ -15,7 +15,10 @@
  */
 
 locals {
-  consumer_quotas = { for index, quota in var.consumer_quotas : "${quota.service}-${quota.metric}" => quota }
+  consumer_quotas = { 
+    for index, quota in var.consumer_quotas : 
+      "${quota.service}-${quota.metric}-${index}" => quota 
+  }
 }
 
 resource "google_service_usage_consumer_quota_override" "override" {


### PR DESCRIPTION
Adds `${index}` to the `consumer_quotas` map allowing multiple quotas using the same metric to be applied.

Addresses issue:  https://github.com/terraform-google-modules/terraform-google-project-factory/issues/890

