### PR TITLE
chore(metadata): add vpc_service_control_attach_dry_run 

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -334,7 +334,12 @@ spec:
     default: ""
     required: false
   - name: vpc_service_control_attach_enabled
-    description: Whether the project will be attached to a VPC Service Control Perimeter
+    description: Whether the project will be attached to a VPC Service Control Perimeter in ENFORCED MODE. vpc_service_control_attach_dry_run should be false for this to be true
+    type: bool
+    default: false
+    required: false
+  - name: vpc_service_control_attach_dry_run
+    description: Whether the project will be attached to a VPC Service Control Perimeter in Dry Run Mode. vpc_service_control_attach_enabled should be false for this to be true
     type: bool
     default: false
     required: false


### PR DESCRIPTION
PR to address https://github.com/terraform-google-modules/terraform-google-project-factory/issues/904

vpc_service_control_attach_dry_run was not previously included in metadata file so it was not exposed to the module