### PR TITLE
fix: include the APIs with identities created in the shared VPC config #946

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -82,7 +82,7 @@ module "shared_vpc_access" {
   enable_shared_vpc_service_project  = var.svpc_host_project_id != "" ? true : false
   host_project_id                    = var.svpc_host_project_id
   service_project_id                 = module.project-factory.project_id
-  active_apis                        = var.activate_apis
+  active_apis                        = toset(concat(var.activate_apis, [for i in var.activate_api_identities : i.api]))
   shared_vpc_subnets                 = var.shared_vpc_subnets
   service_project_number             = module.project-factory.project_number
   lookup_project_numbers             = false

--- a/modules/svpc_service_project/main.tf
+++ b/modules/svpc_service_project/main.tf
@@ -70,7 +70,7 @@ module "shared_vpc_access" {
   host_project_id                    = var.shared_vpc
   enable_shared_vpc_service_project  = true
   service_project_id                 = module.project-factory.project_id
-  active_apis                        = var.activate_apis
+  active_apis                        = toset(concat(var.activate_apis, [for i in var.activate_api_identities : i.api]))
   shared_vpc_subnets                 = var.shared_vpc_subnets
   service_project_number             = module.project-factory.project_number
   lookup_project_numbers             = false


### PR DESCRIPTION
This is a followup of https://github.com/terraform-google-modules/terraform-google-project-factory/pull/934/commits/c1a7e1398c00abd050199aa7ac5db2e2be541860

Fixes #946