### PR TITLE
feat: Add support for granting permissions to apache kafka service agent

### DIFF
--- a/modules/shared_vpc_access/main.tf
+++ b/modules/shared_vpc_access/main.tf
@@ -58,6 +58,10 @@ locals {
       service_account = format("service-%s@gcp-sa-networkconnectivity.iam.gserviceaccount.com", local.service_project_number)
       role            = "roles/compute.networkUser"
     }
+    "managedkafka.googleapis.com" : {
+      service_account = format("service-%s@gcp-sa-managedkafka.iam.gserviceaccount.com", local.service_project_number)
+      role            = "roles/managedkafka.serviceAgent"
+    }
   }
   gke_shared_vpc_enabled        = contains(var.active_apis, "container.googleapis.com")
   composer_shared_vpc_enabled   = contains(var.active_apis, "composer.googleapis.com")


### PR DESCRIPTION
Managed Kafka service agent needs roles/managedkafka.serviceAgent on the subnet that it is assigned as documented [here](https://cloud.google.com/managed-service-for-apache-kafka/docs/networking-kafka#required_permissions).

Note that while the documentation states on the entire project from our testing it seems it is only required on the subnet.