### PR TITLE
feat(core_project_factor): enable setting a description for the default service account

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ determining that location is as follows:
 | name | The name for the project | `string` | n/a | yes |
 | org\_id | The organization ID. | `string` | `null` | no |
 | project\_id | The ID to give the project. If not provided, the `name` will be used. | `string` | `""` | no |
+| project\_sa\_description | Description to set for the project default service account. | `string` | `null` | no |
 | project\_sa\_name | Default service account name for the project. | `string` | `"project-service-account"` | no |
 | random\_project\_id | Adds a suffix of 4 random characters to the `project_id`. | `bool` | `false` | no |
 | random\_project\_id\_length | Sets the length of `random_project_id` to the provided length, and uses a `random_string` for a larger collusion domain.  Recommended for use with CI. | `number` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -45,6 +45,7 @@ module "project-factory" {
   folder_id                          = var.folder_id
   create_project_sa                  = var.create_project_sa
   project_sa_name                    = var.project_sa_name
+  project_sa_description             = var.project_sa_description
   sa_role                            = var.sa_role
   activate_apis                      = var.activate_apis
   activate_api_identities            = var.activate_api_identities

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -134,6 +134,9 @@ spec:
         description: Default service account name for the project.
         varType: string
         defaultValue: project-service-account
+      - name: project_sa_description
+        description: Description to set for the project default service account.
+        varType: string
       - name: sa_role
         description: A role to give the default Service Account for the project (defaults to none)
         varType: string
@@ -310,7 +313,7 @@ spec:
         description: "Managed protection tier to be set. Possible values are: CA_STANDARD, CA_ENTERPRISE_PAYGO"
         varType: string
       - name: deletion_policy
-        description: The deletion policy for the project.
+        description: "The deletion policy for the project. Possible values are: DELETE, PREVENT"
         varType: string
         defaultValue: PREVENT
     outputs:

--- a/modules/core_project_factory/main.tf
+++ b/modules/core_project_factory/main.tf
@@ -153,6 +153,7 @@ resource "google_service_account" "default_service_account" {
   count                        = var.create_project_sa ? 1 : 0
   account_id                   = var.project_sa_name
   display_name                 = "${var.name} Project Service Account"
+  description                  = var.project_sa_description
   project                      = google_project.main.project_id
   create_ignore_already_exists = true
 }

--- a/modules/core_project_factory/variables.tf
+++ b/modules/core_project_factory/variables.tf
@@ -96,6 +96,12 @@ variable "project_sa_name" {
   default     = "project-service-account"
 }
 
+variable "project_sa_description" {
+  description = "Description to set for the project default service account."
+  type        = string
+  default     = null
+}
+
 variable "sa_role" {
   description = "A role to give the default Service Account for the project (defaults to none)"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -96,6 +96,12 @@ variable "project_sa_name" {
   default     = "project-service-account"
 }
 
+variable "project_sa_description" {
+  description = "Description to set for the project default service account."
+  type        = string
+  default     = null
+}
+
 variable "sa_role" {
   description = "A role to give the default Service Account for the project (defaults to none)"
   type        = string


### PR DESCRIPTION
Enable setting a description for the default service account in `core_project_factory`. I am implementing an organization policy that requires our SA's have descriptions and we rely on this SA for new projects, so this minor feature request would help us there. The default is null to prevent changing existing resources.