### PR TITLE
Avoid unnecessary budget changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -102,6 +102,7 @@ module "budget" {
   create_budget = var.budget_amount != null
 
   projects                         = [module.project-factory.project_id]
+  project_numbers                  = [module.project-factory.project_number]
   billing_account                  = var.billing_account
   amount                           = var.budget_amount
   alert_spent_percents             = var.budget_alert_spent_percents

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -382,6 +382,6 @@ spec:
       - serviceusage.googleapis.com
     providerVersions:
       - source: hashicorp/google
-        version: ">= 5.41, < 7"
+        version: ">= 5.41, < 8"
       - source: hashicorp/google-beta
-        version: ">= 5.41, < 7"
+        version: ">= 5.41, < 8"

--- a/modules/budget/README.md
+++ b/modules/budget/README.md
@@ -33,6 +33,7 @@ module "project_myproject" {
 | display\_name | The display name of the budget. If not set defaults to `Budget For <projects[0]|All Projects>` | `string` | `null` | no |
 | labels | A single label and value pair specifying that usage from only this set of labeled resources should be included in the budget. | `map(string)` | `{}` | no |
 | monitoring\_notification\_channels | A list of monitoring notification channels in the form `[projects/{project_id}/notificationChannels/{channel_id}]`. A maximum of 5 channels are allowed. | `list(string)` | `[]` | no |
+| project\_numbers | The project numbers to include in this budget. If empty project numbers will be determined automatically from the projects variable | `list(string)` | `[]` | no |
 | projects | The project ids to include in this budget. If empty budget will include all projects | `list(string)` | n/a | yes |
 | services | A list of services ids to be included in the budget. If omitted, all services will be included in the budget. Service ids can be found at https://cloud.google.com/skus/ | `list(string)` | `null` | no |
 

--- a/modules/budget/metadata.yaml
+++ b/modules/budget/metadata.yaml
@@ -66,6 +66,10 @@ spec:
         description: The project ids to include in this budget. If empty budget will include all projects
         varType: list(string)
         required: true
+      - name: project_numbers
+        description: The project numbers to include in this budget. If empty project numbers will be determined automatically from the projects variable
+        varType: list(string)
+        defaultValue: []
       - name: amount
         description: The amount to use as the budget
         varType: number

--- a/modules/budget/metadata.yaml
+++ b/modules/budget/metadata.yaml
@@ -149,4 +149,4 @@ spec:
       - serviceusage.googleapis.com
     providerVersions:
       - source: hashicorp/google
-        version: ">= 4.28, < 7"
+        version: ">= 4.28, < 8"

--- a/modules/budget/variables.tf
+++ b/modules/budget/variables.tf
@@ -24,6 +24,16 @@ variable "projects" {
   type        = list(string)
 }
 
+variable "project_numbers" {
+  description = "The project numbers to include in this budget. If empty project numbers will be determined automatically from the projects variable"
+  type        = list(string)
+  default     = []
+  validation {
+    condition     = length(var.project_numbers) == 0 || length(var.project_numbers) == length(var.projects)
+    error_message = "Length of project_numbers must match length of projects if project_numbers are provided."
+  }
+}
+
 variable "amount" {
   description = "The amount to use as the budget"
   type        = number

--- a/modules/essential_contacts/metadata.yaml
+++ b/modules/essential_contacts/metadata.yaml
@@ -102,6 +102,6 @@ spec:
       - serviceusage.googleapis.com
     providerVersions:
       - source: hashicorp/google
-        version: ">= 3.43, < 7"
+        version: ">= 3.43, < 8"
       - source: hashicorp/google-beta
-        version: ">= 3.43, < 7"
+        version: ">= 3.43, < 8"

--- a/modules/fabric-project/metadata.yaml
+++ b/modules/fabric-project/metadata.yaml
@@ -176,4 +176,4 @@ spec:
       - serviceusage.googleapis.com
     providerVersions:
       - source: hashicorp/google
-        version: ">= 5.41, < 7"
+        version: ">= 5.41, < 8"

--- a/modules/gsuite_enabled/metadata.yaml
+++ b/modules/gsuite_enabled/metadata.yaml
@@ -275,6 +275,6 @@ spec:
       - source: DeviaVir/gsuite
         version: ~> 0.1
       - source: hashicorp/google
-        version: ">= 4.11, < 7"
+        version: ">= 4.11, < 8"
       - source: hashicorp/google-beta
-        version: ">= 4.11, < 7"
+        version: ">= 4.11, < 8"

--- a/modules/project_services/metadata.yaml
+++ b/modules/project_services/metadata.yaml
@@ -127,6 +127,6 @@ spec:
       - serviceusage.googleapis.com
     providerVersions:
       - source: hashicorp/google
-        version: ">= 3.43, < 7"
+        version: ">= 3.43, < 8"
       - source: hashicorp/google-beta
-        version: ">= 3.43, < 7"
+        version: ">= 3.43, < 8"

--- a/modules/quota_manager/metadata.yaml
+++ b/modules/quota_manager/metadata.yaml
@@ -102,4 +102,4 @@ spec:
       - serviceusage.googleapis.com
     providerVersions:
       - source: hashicorp/google-beta
-        version: ">= 4.11, < 7"
+        version: ">= 4.11, < 8"

--- a/modules/shared_vpc_access/metadata.yaml
+++ b/modules/shared_vpc_access/metadata.yaml
@@ -129,6 +129,6 @@ spec:
       - serviceusage.googleapis.com
     providerVersions:
       - source: hashicorp/google
-        version: ">= 3.43, < 7"
+        version: ">= 3.43, < 8"
       - source: hashicorp/google-beta
-        version: ">= 3.43, < 7"
+        version: ">= 3.43, < 8"

--- a/modules/svpc_service_project/metadata.yaml
+++ b/modules/svpc_service_project/metadata.yaml
@@ -260,6 +260,6 @@ spec:
       - serviceusage.googleapis.com
     providerVersions:
       - source: hashicorp/google
-        version: ">= 4.5, < 7"
+        version: ">= 4.5, < 8"
       - source: hashicorp/google-beta
-        version: ">= 4.5, < 7"
+        version: ">= 4.5, < 8"


### PR DESCRIPTION
Hi, we noticed that almost any change in project settings or change on dependent module, like folder in which the project is created, triggers project number refresh via data resource and plan budget update because of that. The budget update is not performed, because at the apply phase the data resource returns identical project number.

```hcl
  # module.my_project.module.budget.data.google_project.project[0] will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "google_project" "project" {
  ...
      + project_id          = "my-project-1234"
  ...
    }

  # module.my_project.module.budget.google_billing_budget.budget[0] will be updated in-place
  ~ resource "google_billing_budget" "budget" {
  ...
      ~ budget_filter {
          ~ projects               = [
              - "projects/1234567890",
            ] -> (known after apply)
        }
    }

  # module.my_project.module.project-factory.google_service_account.default_service_account[0] will be created
  + resource "google_service_account" "default_service_account" {
      + account_id                   = "project-service-account"
      + create_ignore_already_exists = true
      + disabled                     = false
      + display_name                 = "my-project-1234 Project Service Account"
      + email                        = "project-service-account@my-project-1234.iam.gserviceaccount.com"
      + id                           = (known after apply)
      + member                       = "serviceAccount:project-service-account@my-project-1234.iam.gserviceaccount.com"
      + name                         = (known after apply)
      + project                      = "my-project-1234"
      + unique_id                    = (known after apply)
    }

Plan: 1 to add, 1 to change, 0 to destroy.
```

As the project number is immutable thing and it's known and already available in `core_project_factory` module outputs, I suggest passing it to the budget module directly to avoid using the data resource at all.

To keep the budget module backward compatible and still usable as standalone module, it will still fetch the project numbers when they are not provided directly.
