### PR TITLE
feat!: Deduplicate IAM for cloudservices service agent

### DIFF
--- a/modules/shared_vpc_access/main.tf
+++ b/modules/shared_vpc_access/main.tf
@@ -129,18 +129,15 @@ resource "google_compute_subnetwork_iam_member" "service_shared_vpc_subnet_users
  *****************************************/
 resource "google_compute_subnetwork_iam_member" "cloudservices_shared_vpc_subnet_users" {
   provider = google-beta
-  count    = local.gke_shared_vpc_enabled && var.enable_shared_vpc_service_project && var.grant_network_role ? length(local.subnetwork_api) : 0
+  count    = local.gke_shared_vpc_enabled && var.enable_shared_vpc_service_project && var.grant_network_role ? length(var.shared_vpc_subnets) : 0
   subnetwork = element(
-    split("/", split(",", local.subnetwork_api[count.index])[1]),
-    index(
-      split("/", split(",", local.subnetwork_api[count.index])[1]),
-      "subnetworks",
-    ) + 1,
+    split("/", var.shared_vpc_subnets[count.index]),
+    index(split("/", var.shared_vpc_subnets[count.index]), "subnetworks", ) + 1,
   )
   role = "roles/compute.networkUser"
   region = element(
-    split("/", split(",", local.subnetwork_api[count.index])[1]),
-    index(split("/", split(",", local.subnetwork_api[count.index])[1]), "regions") + 1,
+    split("/", var.shared_vpc_subnets[count.index]),
+    index(split("/", var.shared_vpc_subnets[count.index]), "regions") + 1,
   )
   project = var.host_project_id
   member  = format("serviceAccount:%s@cloudservices.gserviceaccount.com", local.service_project_number)


### PR DESCRIPTION
BREAKING CHANGE: Terraform will remove the IAM for cloudservices service agent and return it on the next run. Can be avoided with removing all the duplicated IAM resources from terraform state manually.

Previous code was creating duplicated IAM for cloudservices service agent. It doesn't matter when creating, but it matters when removing api from active apis list. Then it remove all the IAM for the cloudservices service agent and it gets fixed only with subsequent terraform apply.

See the plan below with two active apis. It creates two identical iam_member resources.

```hcl
# module.shared_vpc_access.google_compute_subnetwork_iam_member.cloudservices_shared_vpc_subnet_users[0] will be created
+ resource "google_compute_subnetwork_iam_member" "cloudservices_shared_vpc_subnet_users" {
    + etag       = (known after apply)
    + id         = (known after apply)
    + member     = "serviceAccount:1234567890@cloudservices.gserviceaccount.com"
    + project    = "my-host-project-1234"
    + region     = "europe-west1"
    + role       = "roles/compute.networkUser"
    + subnetwork = "subnet1"
  }
# module.shared_vpc_access.google_compute_subnetwork_iam_member.cloudservices_shared_vpc_subnet_users[1] will be created
+ resource "google_compute_subnetwork_iam_member" "cloudservices_shared_vpc_subnet_users" {
    + etag       = (known after apply)
    + id         = (known after apply)
    + member     = "serviceAccount:1234567890@cloudservices.gserviceaccount.com"
    + project    = "my-host-project-1234"
    + region     = "europe-west1"
    + role       = "roles/compute.networkUser"
    + subnetwork = "subnet1"
  }
```