### PR TITLE
feat: make project lien reason customizable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -31,6 +31,7 @@ module "project-factory" {
   group_email                        = module.gsuite_group.email
   group_role                         = var.group_role
   lien                               = var.lien
+  lien_reason                        = var.lien_reason
   manage_group                       = var.group_name != "" ? true : false
   random_project_id                  = var.random_project_id
   random_project_id_length           = var.random_project_id_length

--- a/modules/core_project_factory/main.tf
+++ b/modules/core_project_factory/main.tf
@@ -96,7 +96,7 @@ resource "google_resource_manager_lien" "lien" {
   parent       = "projects/${google_project.main.number}"
   restrictions = ["resourcemanager.projects.delete"]
   origin       = "project-factory"
-  reason       = "Project Factory lien"
+  reason       = var.lien_reason != "" ? var.lien_reason : "Project Factory lien"
 }
 
 /******************************************

--- a/modules/core_project_factory/variables.tf
+++ b/modules/core_project_factory/variables.tf
@@ -32,6 +32,12 @@ variable "lien" {
   type        = bool
 }
 
+variable "lien_reason" {
+  description = "The reason for the lien on the project. If not provided, defaults to 'Project Factory lien'"
+  type        = string
+  default     = ""
+}
+
 variable "manage_group" {
   description = "A toggle to indicate if a G Suite group should be managed."
   type        = bool

--- a/modules/gsuite_enabled/main.tf
+++ b/modules/gsuite_enabled/main.tf
@@ -73,6 +73,7 @@ module "project-factory" {
   )
   group_role                        = var.group_role
   lien                              = var.lien
+  lien_reason                       = var.lien_reason
   manage_group                      = var.group_name != "" || var.create_group
   random_project_id                 = var.random_project_id
   org_id                            = var.org_id

--- a/modules/gsuite_enabled/variables.tf
+++ b/modules/gsuite_enabled/variables.tf
@@ -20,6 +20,12 @@ variable "lien" {
   type        = bool
 }
 
+variable "lien_reason" {
+  description = "The reason for the lien on the project. If not provided, defaults to 'Project Factory lien'"
+  type        = string
+  default     = ""
+}
+
 variable "random_project_id" {
   description = "Adds a suffix of 4 random characters to the `project_id`"
   type        = bool

--- a/modules/svpc_service_project/main.tf
+++ b/modules/svpc_service_project/main.tf
@@ -31,6 +31,7 @@ module "project-factory" {
   group_email                       = module.gsuite_group.email
   group_role                        = var.group_role
   lien                              = var.lien
+  lien_reason                       = var.lien_reason
   manage_group                      = var.group_name != "" ? true : false
   random_project_id                 = var.random_project_id
   org_id                            = var.org_id

--- a/modules/svpc_service_project/variables.tf
+++ b/modules/svpc_service_project/variables.tf
@@ -169,6 +169,12 @@ variable "lien" {
   default     = false
 }
 
+variable "lien_reason" {
+  description = "The reason for the lien on the project. If not provided, defaults to 'Project Factory lien'"
+  type        = string
+  default     = ""
+}
+
 variable "disable_services_on_destroy" {
   description = "Whether project services will be disabled when the resources are destroyed"
   default     = true

--- a/variables.tf
+++ b/variables.tf
@@ -212,6 +212,12 @@ variable "lien" {
   default     = false
 }
 
+variable "lien_reason" {
+  description = "The reason for the lien on the project. If not provided, defaults to 'Project Factory lien'"
+  type        = string
+  default     = ""
+}
+
 variable "disable_services_on_destroy" {
   description = "Whether project services will be disabled when the resources are destroyed"
   default     = true


### PR DESCRIPTION
Add lien_reason variable to allow customization of the project lien message.

The variable defaults to empty string and falls back to "Project Factory lien" when not provided, maintaining backward compatibility. 