### PR TITLE
feat: add support for other Google Universes

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ determining that location is as follows:
 | lien | Add a lien on the project to prevent accidental deletion | `bool` | `false` | no |
 | name | The name for the project | `string` | n/a | yes |
 | org\_id | The organization ID. | `string` | `null` | no |
+| principal\_set | A principalSet URI to control the project. If provided, this is used instead of group\_name. | `string` | `""` | no |
 | project\_id | The ID to give the project. If not provided, the `name` will be used. | `string` | `""` | no |
 | project\_sa\_description | Description to set for the project default service account. | `string` | `null` | no |
 | project\_sa\_name | Default service account name for the project. | `string` | `"project-service-account"` | no |
@@ -162,6 +163,7 @@ determining that location is as follows:
 | shared\_vpc\_subnets | List of subnets fully qualified subnet IDs (ie. projects/$project\_id/regions/$region/subnetworks/$subnet\_id) | `list(string)` | `[]` | no |
 | svpc\_host\_project\_id | The ID of the host project which hosts the shared VPC | `string` | `""` | no |
 | tag\_binding\_values | Tag values to bind the project to. | `list(string)` | `[]` | no |
+| universe\_prefix | The universe short name prefix to prepend to the project ID (e.g., 'eu0'). A colon (:) is automatically appended to the project ID, and a hyphen (-) is used for the state bucket name. | `string` | `""` | no |
 | usage\_bucket\_name | Name of a GCS bucket to store GCE usage reports in (optional) | `string` | `""` | no |
 | usage\_bucket\_prefix | Prefix in the GCS bucket to store GCE usage reports in (optional) | `string` | `""` | no |
 | vpc\_service\_control\_attach\_dry\_run | Whether the project will be attached to a VPC Service Control Perimeter in Dry Run Mode. vpc\_service\_control\_attach\_enabled should be false for this to be true | `bool` | `false` | no |

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -135,7 +135,7 @@ steps:
   waitFor:
       - create-all
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && export TF_VAR_policy_id=$(gcloud access-context-manager policies list --organization="${TF_VAR_org_id:?}" --format="value(name)" --filter="title:default policy") && kitchen_do converge vpc-sc-project-local']
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && export TF_VAR_policy_id=$(gcloud access-context-manager policies list --organization="${TF_VAR_org_id:?}" --format="value(name)" --filter="-scopes:*") && kitchen_do converge vpc-sc-project-local']
 - id: verify vpc-sc-project-local
   waitFor:
       - converge vpc-sc-project-local
@@ -145,7 +145,7 @@ steps:
   waitFor:
     - verify vpc-sc-project-local
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && export TF_VAR_policy_id=$(gcloud access-context-manager policies list --organization="${TF_VAR_org_id:?}" --format="value(name)" --filter="title:default policy") && kitchen_do destroy vpc-sc-project-local']
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && export TF_VAR_policy_id=$(gcloud access-context-manager policies list --organization="${TF_VAR_org_id:?}" --format="value(name)" --filter="-scopes:*") && kitchen_do destroy vpc-sc-project-local']
 
 - id: init-quota-project-example
   waitFor:

--- a/main.tf
+++ b/main.tf
@@ -28,12 +28,13 @@ module "gsuite_group" {
 module "project-factory" {
   source = "./modules/core_project_factory"
 
-  group_email                        = module.gsuite_group.email
+  group_email                        = var.principal_set != "" ? var.principal_set : module.gsuite_group.email
   group_role                         = var.group_role
   lien                               = var.lien
-  manage_group                       = var.group_name != "" ? true : false
+  manage_group                       = var.group_name != "" || var.principal_set != ""
   random_project_id                  = var.random_project_id
   random_project_id_length           = var.random_project_id_length
+  universe_prefix                    = var.universe_prefix
   org_id                             = var.folder_id != "" ? null : var.org_id
   name                               = var.name
   project_id                         = var.project_id

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -87,6 +87,10 @@ spec:
       - name: random_project_id_length
         description: Sets the length of `random_project_id` to the provided length, and uses a `random_string` for a larger collusion domain.  Recommended for use with CI.
         varType: number
+      - name: universe_prefix
+        description: The universe short name prefix to prepend to the project ID (e.g., 'eu0'). A colon (:) is automatically appended to the project ID, and a hyphen (-) is used for the state bucket name.
+        varType: string
+        defaultValue: ""
       - name: org_id
         description: The organization ID.
         varType: string
@@ -120,6 +124,10 @@ spec:
         defaultValue: ""
       - name: group_name
         description: A group to control the project by being assigned group_role (defaults to project editor)
+        varType: string
+        defaultValue: ""
+      - name: principal_set
+        description: A principalSet URI to control the project. If provided, this is used instead of group_name.
         varType: string
         defaultValue: ""
       - name: group_role
@@ -359,12 +367,12 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/iam.serviceAccountUser
+          - roles/billing.projectManager
           - roles/compute.admin
           - roles/iam.serviceAccountAdmin
           - roles/resourcemanager.projectIamAdmin
           - roles/storage.admin
-          - roles/iam.serviceAccountUser
-          - roles/billing.projectManager
     services:
       - accesscontextmanager.googleapis.com
       - admin.googleapis.com
@@ -382,6 +390,6 @@ spec:
       - serviceusage.googleapis.com
     providerVersions:
       - source: hashicorp/google
-        version: ">= 5.41, < 7"
+        version: ">= 5.41, < 8"
       - source: hashicorp/google-beta
-        version: ">= 5.41, < 7"
+        version: ">= 5.41, < 8"

--- a/modules/budget/metadata.yaml
+++ b/modules/budget/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -122,12 +122,12 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/billing.projectManager
           - roles/compute.admin
           - roles/iam.serviceAccountAdmin
           - roles/resourcemanager.projectIamAdmin
           - roles/storage.admin
           - roles/iam.serviceAccountUser
+          - roles/billing.projectManager
     services:
       - accesscontextmanager.googleapis.com
       - admin.googleapis.com
@@ -145,4 +145,4 @@ spec:
       - serviceusage.googleapis.com
     providerVersions:
       - source: hashicorp/google
-        version: ">= 4.28, < 7"
+        version: ">= 4.28, < 8"

--- a/modules/core_project_factory/main.tf
+++ b/modules/core_project_factory/main.tf
@@ -33,7 +33,7 @@ resource "random_string" "random_project_id_suffix" {
  *****************************************/
 locals {
   use_random_string = try(var.random_project_id_length > 0, false)
-  group_id = var.manage_group ? (
+  group_id = var.manage_group && var.group_email != "" ? (
     startswith(var.group_email, "principalSet://") || startswith(var.group_email, "group:") ? var.group_email : "group:${var.group_email}"
   ) : ""
   base_project_id   = var.project_id == "" ? var.name : var.project_id

--- a/modules/core_project_factory/main.tf
+++ b/modules/core_project_factory/main.tf
@@ -46,7 +46,8 @@ locals {
     local.use_random_string ? random_string.random_project_id_suffix[0].result : random_id.random_project_id_suffix.hex,
   ) : local.base_project_id
 
-  extracted_prefix       = length(regexall(":", var.project_id)) > 0 ? split(":", var.project_id)[0] : ""
+  raw_prefix             = length(regexall(":", local.base_project_id)) > 0 ? split(":", local.base_project_id)[0] : ""
+  extracted_prefix       = length(regexall("\\.", local.raw_prefix)) > 0 ? "" : local.raw_prefix
   active_universe_prefix = var.universe_prefix != "" ? var.universe_prefix : local.extracted_prefix
 
   temp_project_id = (var.universe_prefix != "" && local.extracted_prefix == "") ? format(

--- a/modules/core_project_factory/main.tf
+++ b/modules/core_project_factory/main.tf
@@ -49,7 +49,7 @@ locals {
   raw_prefix = length(regexall(":", local.base_project_id)) > 0 ? split(":", local.base_project_id)[0] : ""
   // check for domain-scoped projects like "example.com:project-id"
   extracted_prefix       = length(regexall("\\.", local.raw_prefix)) > 0 ? "" : local.raw_prefix
-  active_universe_prefix = var.universe_prefix != "" ? var.universe_prefix : local.extracted_prefix
+  active_universe_prefix = local.extracted_prefix != "" ? local.extracted_prefix : var.universe_prefix
 
   temp_project_id = (var.universe_prefix != "" && local.extracted_prefix == "") ? format(
     "%s:%s",

--- a/modules/core_project_factory/main.tf
+++ b/modules/core_project_factory/main.tf
@@ -33,27 +33,43 @@ resource "random_string" "random_project_id_suffix" {
  *****************************************/
 locals {
   use_random_string = try(var.random_project_id_length > 0, false)
-  group_id          = var.manage_group ? format("group:%s", var.group_email) : ""
+  group_id = var.manage_group ? (
+    startswith(var.group_email, "principalSet://") || startswith(var.group_email, "group:") ? var.group_email : "group:${var.group_email}"
+  ) : ""
   base_project_id   = var.project_id == "" ? var.name : var.project_id
   project_org_id    = var.folder_id != "" ? null : var.org_id
   project_folder_id = var.folder_id != "" ? var.folder_id : null
-  temp_project_id = var.random_project_id ? format(
+
+  project_id_no_prefix = var.random_project_id ? format(
     "%s-%s",
     local.base_project_id,
     local.use_random_string ? random_string.random_project_id_suffix[0].result : random_id.random_project_id_suffix.hex,
   ) : local.base_project_id
+
+  extracted_prefix       = length(regexall(":", var.project_id)) > 0 ? split(":", var.project_id)[0] : ""
+  active_universe_prefix = var.universe_prefix != "" ? var.universe_prefix : local.extracted_prefix
+
+  temp_project_id = (var.universe_prefix != "" && local.extracted_prefix == "") ? format(
+    "%s:%s",
+    var.universe_prefix,
+    local.project_id_no_prefix
+  ) : local.project_id_no_prefix
+
   s_account_fmt = var.create_project_sa ? format(
     "serviceAccount:%s",
     try(google_service_account.default_service_account[0].email, ""),
   ) : ""
+  s_account_domain = local.active_universe_prefix != "" ? "${local.active_universe_prefix}-system.iam.gserviceaccount.com" : "gserviceaccount.com"
   api_s_account = format(
-    "%s@cloudservices.gserviceaccount.com",
+    "%s@cloudservices.%s",
     google_project.main.number,
+    local.s_account_domain
   )
-  activate_apis       = var.activate_apis
-  api_s_account_fmt   = format("serviceAccount:%s", local.api_s_account)
-  project_bucket_name = var.bucket_name != "" ? var.bucket_name : format("%s-state", local.temp_project_id)
-  create_bucket       = var.bucket_project != "" ? true : false
+  activate_apis          = var.activate_apis
+  api_s_account_fmt      = format("serviceAccount:%s", local.api_s_account)
+  bucket_safe_project_id = replace(local.temp_project_id, ":", "-")
+  project_bucket_name    = var.bucket_name != "" ? var.bucket_name : format("%s-state", local.bucket_safe_project_id)
+  create_bucket          = var.bucket_project != "" ? true : false
 
   shared_vpc_users = compact(
     [

--- a/modules/core_project_factory/main.tf
+++ b/modules/core_project_factory/main.tf
@@ -46,7 +46,8 @@ locals {
     local.use_random_string ? random_string.random_project_id_suffix[0].result : random_id.random_project_id_suffix.hex,
   ) : local.base_project_id
 
-  raw_prefix             = length(regexall(":", local.base_project_id)) > 0 ? split(":", local.base_project_id)[0] : ""
+  raw_prefix = length(regexall(":", local.base_project_id)) > 0 ? split(":", local.base_project_id)[0] : ""
+  // check for domain-scoped projects like "example.com:project-id"
   extracted_prefix       = length(regexall("\\.", local.raw_prefix)) > 0 ? "" : local.raw_prefix
   active_universe_prefix = var.universe_prefix != "" ? var.universe_prefix : local.extracted_prefix
 

--- a/modules/core_project_factory/main.tf
+++ b/modules/core_project_factory/main.tf
@@ -22,7 +22,8 @@ resource "random_id" "random_project_id_suffix" {
 }
 
 resource "random_string" "random_project_id_suffix" {
-  count   = local.use_random_string ? 1 : 0
+  count = local.use_random_string ? 1 : 0
+
   length  = var.random_project_id_length
   special = false
   upper   = false
@@ -110,7 +111,8 @@ resource "google_project" "main" {
   Project lien
  *****************************************/
 resource "google_resource_manager_lien" "lien" {
-  count        = var.lien ? 1 : 0
+  count = var.lien ? 1 : 0
+
   parent       = "projects/${google_project.main.number}"
   restrictions = ["resourcemanager.projects.delete"]
   origin       = "project-factory"
@@ -134,15 +136,16 @@ module "project_services" {
   Shared VPC configuration
  *****************************************/
 resource "time_sleep" "wait_5_seconds" { #TODO rename resource in the next breaking change.
-  count           = var.vpc_service_control_attach_enabled || var.vpc_service_control_attach_dry_run ? 1 : 0
+  count = var.vpc_service_control_attach_enabled || var.vpc_service_control_attach_dry_run ? 1 : 0
+
   depends_on      = [google_access_context_manager_service_perimeter_resource.service_perimeter_attachment[0], google_project_service.enable_access_context_manager[0]]
   create_duration = var.vpc_service_control_sleep_duration
 }
 
 resource "google_compute_shared_vpc_service_project" "shared_vpc_attachment" {
   provider = google-beta
+  count    = var.enable_shared_vpc_service_project ? 1 : 0
 
-  count           = var.enable_shared_vpc_service_project ? 1 : 0
   host_project    = var.shared_vpc
   service_project = google_project.main.project_id
   depends_on      = [time_sleep.wait_5_seconds[0], module.project_services]
@@ -150,14 +153,15 @@ resource "google_compute_shared_vpc_service_project" "shared_vpc_attachment" {
 
 resource "google_compute_shared_vpc_host_project" "shared_vpc_host" {
   provider = google-beta
+  count    = var.enable_shared_vpc_host_project ? 1 : 0
 
-  count      = var.enable_shared_vpc_host_project ? 1 : 0
   project    = google_project.main.project_id
   depends_on = [module.project_services]
 }
 
 resource "google_project_default_service_accounts" "default_service_accounts" {
-  count          = upper(var.default_service_account) == "KEEP" ? 0 : 1
+  count = upper(var.default_service_account) == "KEEP" ? 0 : 1
+
   action         = upper(var.default_service_account)
   project        = google_project.main.project_id
   restore_policy = "REVERT_AND_IGNORE_FAILURE"
@@ -168,7 +172,8 @@ resource "google_project_default_service_accounts" "default_service_accounts" {
   Default Service Account configuration
  *****************************************/
 resource "google_service_account" "default_service_account" {
-  count                        = var.create_project_sa ? 1 : 0
+  count = var.create_project_sa ? 1 : 0
+
   account_id                   = var.project_sa_name
   display_name                 = "${var.name} Project Service Account"
   description                  = var.project_sa_description
@@ -180,7 +185,8 @@ resource "google_service_account" "default_service_account" {
   Policy to operate instances in shared subnetwork
  *************************************************/
 resource "google_project_iam_member" "default_service_account_membership" {
-  count   = var.sa_role != "" && var.create_project_sa ? 1 : 0
+  count = var.sa_role != "" && var.create_project_sa ? 1 : 0
+
   project = google_project.main.project_id
   role    = var.sa_role
 
@@ -253,8 +259,8 @@ resource "google_compute_subnetwork_iam_member" "service_account_role_to_vpc_sub
  *************************************************************************************/
 resource "google_compute_subnetwork_iam_member" "group_role_to_vpc_subnets" {
   provider = google-beta
+  count    = var.grant_network_role && var.enable_shared_vpc_service_project && length(var.shared_vpc_subnets) > 0 && var.manage_group ? length(var.shared_vpc_subnets) : 0
 
-  count = var.grant_network_role && var.enable_shared_vpc_service_project && length(var.shared_vpc_subnets) > 0 && var.manage_group ? length(var.shared_vpc_subnets) : 0
   subnetwork = element(
     split("/", var.shared_vpc_subnets[count.index]),
     index(
@@ -276,8 +282,8 @@ resource "google_compute_subnetwork_iam_member" "group_role_to_vpc_subnets" {
  *************************************************************************************/
 resource "google_compute_subnetwork_iam_member" "apis_service_account_role_to_vpc_subnets" {
   provider = google-beta
+  count    = var.grant_network_role && var.enable_shared_vpc_service_project && length(var.shared_vpc_subnets) > 0 ? length(var.shared_vpc_subnets) : 0
 
-  count = var.grant_network_role && var.enable_shared_vpc_service_project && length(var.shared_vpc_subnets) > 0 ? length(var.shared_vpc_subnets) : 0
   subnetwork = element(
     split("/", var.shared_vpc_subnets[count.index]),
     index(
@@ -318,8 +324,7 @@ resource "google_project_usage_export_bucket" "usage_report_export" {
  ***********************************************/
 resource "google_storage_bucket" "project_bucket" {
   provider = google-beta
-
-  count = local.create_bucket ? 1 : 0
+  count    = local.create_bucket ? 1 : 0
 
   name                        = local.project_bucket_name
   project                     = var.bucket_project == local.base_project_id ? google_project.main.project_id : var.bucket_project
@@ -375,7 +380,8 @@ resource "google_storage_bucket_iam_member" "api_s_account_storage_admin_on_proj
   Attachment to VPC Service Control Perimeter in Enforce Mode
  *****************************************/
 resource "google_access_context_manager_service_perimeter_resource" "service_perimeter_attachment" {
-  count          = var.vpc_service_control_attach_enabled ? 1 : 0
+  count = var.vpc_service_control_attach_enabled ? 1 : 0
+
   depends_on     = [google_service_account.default_service_account]
   perimeter_name = var.vpc_service_control_perimeter_name
   resource       = "projects/${google_project.main.number}"
@@ -385,7 +391,8 @@ resource "google_access_context_manager_service_perimeter_resource" "service_per
   Attachment to VPC Service Control Perimeter in Dry Run Mode
  *****************************************/
 resource "google_access_context_manager_service_perimeter_dry_run_resource" "service_perimeter_attachment_dry_run" {
-  count          = var.vpc_service_control_attach_dry_run && !var.vpc_service_control_attach_enabled ? 1 : 0
+  count = var.vpc_service_control_attach_dry_run && !var.vpc_service_control_attach_enabled ? 1 : 0
+
   depends_on     = [google_service_account.default_service_account]
   perimeter_name = var.vpc_service_control_perimeter_name
   resource       = "projects/${google_project.main.number}"
@@ -395,7 +402,8 @@ resource "google_access_context_manager_service_perimeter_dry_run_resource" "ser
   Enable Access Context Manager API
  *****************************************/
 resource "google_project_service" "enable_access_context_manager" {
-  count   = var.vpc_service_control_attach_enabled || var.vpc_service_control_attach_dry_run ? 1 : 0
+  count = var.vpc_service_control_attach_enabled || var.vpc_service_control_attach_dry_run ? 1 : 0
+
   project = google_project.main.number
   service = "accesscontextmanager.googleapis.com"
 }
@@ -404,13 +412,15 @@ resource "google_project_service" "enable_access_context_manager" {
   Configure default Network Service Tier
  *****************************************/
 resource "google_compute_project_default_network_tier" "default" {
-  count        = var.default_network_tier != "" ? 1 : 0
+  count = var.default_network_tier != "" ? 1 : 0
+
   project      = google_project.main.number
   network_tier = var.default_network_tier
 }
 
 resource "google_tags_tag_binding" "bindings" {
-  for_each  = toset(var.tag_binding_values)
+  for_each = toset(var.tag_binding_values)
+
   parent    = "//cloudresourcemanager.googleapis.com/projects/${google_project.main.number}"
   tag_value = "tagValues/${each.value}"
 }

--- a/modules/core_project_factory/variables.tf
+++ b/modules/core_project_factory/variables.tf
@@ -15,7 +15,7 @@
  */
 
 variable "group_email" {
-  description = "The email address of a group to control the project by being assigned group_role."
+  description = "The identifier of the group to control the project by being assigned group_role. This can be a standard Google Group email address or a principalSet URI (e.g., 'principalSet://...'). The module automatically applies the 'group:' prefix to standard emails."
   type        = string
   default     = ""
 }
@@ -54,6 +54,12 @@ variable "random_project_id_length" {
   description = "Sets the length of `random_project_id` to the provided length, and uses a `random_string` for a larger collusion domain.  Recommended for use with CI."
   type        = number
   default     = null
+}
+
+variable "universe_prefix" {
+  description = "The universe short name prefix to prepend to the project ID (e.g., 'eu0'). A colon (:) is automatically appended to the project ID, and a hyphen (-) is used for the state bucket name."
+  type        = string
+  default     = ""
 }
 
 variable "org_id" {

--- a/modules/core_project_factory/variables.tf
+++ b/modules/core_project_factory/variables.tf
@@ -60,6 +60,11 @@ variable "universe_prefix" {
   description = "The universe short name prefix to prepend to the project ID (e.g., 'eu0'). A colon (:) is automatically appended to the project ID, and a hyphen (-) is used for the state bucket name."
   type        = string
   default     = ""
+
+  validation {
+    condition     = var.universe_prefix == "" || can(regex("^[a-z0-9]+$", var.universe_prefix))
+    error_message = "The universe_prefix variable must be empty or contain only lowercase alphanumeric characters."
+  }
 }
 
 variable "org_id" {

--- a/modules/essential_contacts/metadata.yaml
+++ b/modules/essential_contacts/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -79,12 +79,12 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/compute.admin
-          - roles/iam.serviceAccountAdmin
-          - roles/resourcemanager.projectIamAdmin
           - roles/storage.admin
           - roles/iam.serviceAccountUser
           - roles/billing.projectManager
+          - roles/compute.admin
+          - roles/iam.serviceAccountAdmin
+          - roles/resourcemanager.projectIamAdmin
     services:
       - accesscontextmanager.googleapis.com
       - admin.googleapis.com
@@ -102,6 +102,6 @@ spec:
       - serviceusage.googleapis.com
     providerVersions:
       - source: hashicorp/google
-        version: ">= 3.43, < 7"
+        version: ">= 3.43, < 8"
       - source: hashicorp/google-beta
-        version: ">= 3.43, < 7"
+        version: ">= 3.43, < 8"

--- a/modules/fabric-project/README.md
+++ b/modules/fabric-project/README.md
@@ -52,6 +52,7 @@ module "project_myproject" {
 | owners | Optional list of IAM-format members to set as project owners. | `list(string)` | `[]` | no |
 | parent | The resource name of the parent Folder or Organization. Must be of the form folders/folder\_id or organizations/org\_id. | `string` | n/a | yes |
 | prefix | Prefix used to generate project id and name. | `string` | n/a | yes |
+| universe\_prefix | The universe short name prefix to prepend to the project ID (e.g., 'eu0'). A colon (:) is automatically appended to the project ID, and a hyphen (-) is used for the state bucket name. | `string` | `""` | no |
 | viewers | Optional list of IAM-format members to set as project viewers. | `list(string)` | `[]` | no |
 
 ## Outputs

--- a/modules/fabric-project/main.tf
+++ b/modules/fabric-project/main.tf
@@ -18,19 +18,23 @@
 # https://github.com/hashicorp/terraform/issues/3116
 
 locals {
-  cloudsvc_service_account = "${google_project.project.number}@cloudservices.gserviceaccount.com"
-  all_oslogin_users        = concat(var.oslogin_users, var.oslogin_admins)
-  num_oslogin_users        = length(var.oslogin_users) + length(var.oslogin_admins)
-  gce_service_account      = "${google_project.project.number}-compute@developer.gserviceaccount.com"
-  gke_service_account      = "service-${google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
-  parent_type              = split("/", var.parent)[0]
-  parent_id                = split("/", var.parent)[1]
+  gsa_domain     = var.universe_prefix != "" ? "${var.universe_prefix}-system.iam.gserviceaccount.com" : "gserviceaccount.com"
+  iam_gsa_domain = var.universe_prefix != "" ? "${var.universe_prefix}-system.iam.gserviceaccount.com" : "iam.gserviceaccount.com"
+
+  cloudsvc_service_account = "${google_project.project.number}@cloudservices.${local.gsa_domain}"
+  gce_service_account      = "${google_project.project.number}-compute@developer.${local.gsa_domain}"
+  gke_service_account      = "service-${google_project.project.number}@container-engine-robot.${local.iam_gsa_domain}"
+
+  all_oslogin_users = concat(var.oslogin_users, var.oslogin_admins)
+  num_oslogin_users = length(var.oslogin_users) + length(var.oslogin_admins)
+  parent_type       = split("/", var.parent)[0]
+  parent_id         = split("/", var.parent)[1]
 }
 
 resource "google_project" "project" {
   org_id              = local.parent_type == "organizations" ? local.parent_id : null
   folder_id           = local.parent_type == "folders" ? local.parent_id : null
-  project_id          = "${var.prefix}-${var.name}"
+  project_id          = var.universe_prefix != "" ? "${var.universe_prefix}:${var.prefix}-${var.name}" : "${var.prefix}-${var.name}"
   name                = "${var.prefix}-${var.name}"
   billing_account     = var.billing_account
   auto_create_network = var.auto_create_network
@@ -147,4 +151,3 @@ resource "google_project_iam_member" "gce_service_account" {
   )
   member = "serviceAccount:${local.gce_service_account}"
 }
-

--- a/modules/fabric-project/metadata.yaml
+++ b/modules/fabric-project/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -66,6 +66,10 @@ spec:
         description: Prefix used to generate project id and name.
         varType: string
         required: true
+      - name: universe_prefix
+        description: The universe short name prefix to prepend to the project ID (e.g., 'eu0'). A colon (:) is automatically appended to the project ID, and a hyphen (-) is used for the state bucket name.
+        varType: string
+        defaultValue: ""
       - name: name
         description: Project name and id suffix.
         varType: string
@@ -153,12 +157,12 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/compute.admin
+          - roles/iam.serviceAccountAdmin
           - roles/resourcemanager.projectIamAdmin
           - roles/storage.admin
           - roles/iam.serviceAccountUser
           - roles/billing.projectManager
-          - roles/compute.admin
-          - roles/iam.serviceAccountAdmin
     services:
       - accesscontextmanager.googleapis.com
       - admin.googleapis.com
@@ -176,4 +180,4 @@ spec:
       - serviceusage.googleapis.com
     providerVersions:
       - source: hashicorp/google
-        version: ">= 5.41, < 7"
+        version: ">= 5.41, < 8"

--- a/modules/fabric-project/variables.tf
+++ b/modules/fabric-project/variables.tf
@@ -28,6 +28,11 @@ variable "universe_prefix" {
   description = "The universe short name prefix to prepend to the project ID (e.g., 'eu0'). A colon (:) is automatically appended to the project ID, and a hyphen (-) is used for the state bucket name."
   type        = string
   default     = ""
+
+  validation {
+    condition     = var.universe_prefix == "" || can(regex("^[a-z0-9]+$", var.universe_prefix))
+    error_message = "The universe_prefix variable must be empty or contain only lowercase alphanumeric characters."
+  }
 }
 
 variable "name" {

--- a/modules/fabric-project/variables.tf
+++ b/modules/fabric-project/variables.tf
@@ -24,6 +24,12 @@ variable "prefix" {
   type        = string
 }
 
+variable "universe_prefix" {
+  description = "The universe short name prefix to prepend to the project ID (e.g., 'eu0'). A colon (:) is automatically appended to the project ID, and a hyphen (-) is used for the state bucket name."
+  type        = string
+  default     = ""
+}
+
 variable "name" {
   description = "Project name and id suffix."
   type        = string

--- a/modules/gsuite_enabled/metadata.yaml
+++ b/modules/gsuite_enabled/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -250,12 +250,12 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/iam.serviceAccountUser
-          - roles/billing.projectManager
           - roles/compute.admin
           - roles/iam.serviceAccountAdmin
           - roles/resourcemanager.projectIamAdmin
           - roles/storage.admin
+          - roles/iam.serviceAccountUser
+          - roles/billing.projectManager
     services:
       - accesscontextmanager.googleapis.com
       - admin.googleapis.com
@@ -275,6 +275,6 @@ spec:
       - source: DeviaVir/gsuite
         version: ~> 0.1
       - source: hashicorp/google
-        version: ">= 4.11, < 7"
+        version: ">= 4.11, < 8"
       - source: hashicorp/google-beta
-        version: ">= 4.11, < 7"
+        version: ">= 4.11, < 8"

--- a/modules/project_services/metadata.yaml
+++ b/modules/project_services/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -104,12 +104,12 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/iam.serviceAccountAdmin
-          - roles/resourcemanager.projectIamAdmin
           - roles/storage.admin
           - roles/iam.serviceAccountUser
           - roles/billing.projectManager
           - roles/compute.admin
+          - roles/iam.serviceAccountAdmin
+          - roles/resourcemanager.projectIamAdmin
     services:
       - accesscontextmanager.googleapis.com
       - admin.googleapis.com
@@ -127,6 +127,6 @@ spec:
       - serviceusage.googleapis.com
     providerVersions:
       - source: hashicorp/google
-        version: ">= 3.43, < 7"
+        version: ">= 3.43, < 8"
       - source: hashicorp/google-beta
-        version: ">= 3.43, < 7"
+        version: ">= 3.43, < 8"

--- a/modules/quota_manager/metadata.yaml
+++ b/modules/quota_manager/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -79,12 +79,12 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/billing.projectManager
           - roles/compute.admin
           - roles/iam.serviceAccountAdmin
           - roles/resourcemanager.projectIamAdmin
           - roles/storage.admin
           - roles/iam.serviceAccountUser
-          - roles/billing.projectManager
     services:
       - accesscontextmanager.googleapis.com
       - admin.googleapis.com
@@ -102,4 +102,4 @@ spec:
       - serviceusage.googleapis.com
     providerVersions:
       - source: hashicorp/google-beta
-        version: ">= 4.11, < 7"
+        version: ">= 4.11, < 8"

--- a/modules/shared_vpc_access/main.tf
+++ b/modules/shared_vpc_access/main.tf
@@ -20,7 +20,8 @@ data "google_project" "service_project" {
 }
 
 locals {
-  raw_prefix       = length(regexall(":", var.service_project_id)) > 0 ? split(":", var.service_project_id)[0] : ""
+  raw_prefix = length(regexall(":", var.service_project_id)) > 0 ? split(":", var.service_project_id)[0] : ""
+  // check for domain-scoped projects like "example.com:project-id"
   extracted_prefix = length(regexall("\\.", local.raw_prefix)) > 0 ? "" : local.raw_prefix
   gsa_domain       = local.extracted_prefix != "" ? "${local.extracted_prefix}-system.iam.gserviceaccount.com" : "gserviceaccount.com"
   iam_gsa_domain   = local.extracted_prefix != "" ? "${local.extracted_prefix}-system.iam.gserviceaccount.com" : "iam.gserviceaccount.com"

--- a/modules/shared_vpc_access/main.tf
+++ b/modules/shared_vpc_access/main.tf
@@ -20,54 +20,58 @@ data "google_project" "service_project" {
 }
 
 locals {
+  extracted_prefix = length(regexall(":", var.service_project_id)) > 0 ? split(":", var.service_project_id)[0] : ""
+  gsa_domain       = local.extracted_prefix != "" ? "${local.extracted_prefix}-system.iam.gserviceaccount.com" : "gserviceaccount.com"
+  iam_gsa_domain   = local.extracted_prefix != "" ? "${local.extracted_prefix}-system.iam.gserviceaccount.com" : "iam.gserviceaccount.com"
+
   service_project_number = var.lookup_project_numbers ? data.google_project.service_project[0].number : var.service_project_number
   apis = {
     "container.googleapis.com" : {
-      service_account = format("service-%s@container-engine-robot.iam.gserviceaccount.com", local.service_project_number)
+      service_account = format("service-%s@container-engine-robot.%s", local.service_project_number, local.iam_gsa_domain)
       role            = "roles/compute.networkUser"
     }
     "dataproc.googleapis.com" : {
-      service_account = format("service-%s@dataproc-accounts.iam.gserviceaccount.com", local.service_project_number)
+      service_account = format("service-%s@dataproc-accounts.%s", local.service_project_number, local.iam_gsa_domain)
       role            = "roles/compute.networkUser"
     },
     "dataflow.googleapis.com" : {
-      service_account = format("service-%s@dataflow-service-producer-prod.iam.gserviceaccount.com", local.service_project_number)
+      service_account = format("service-%s@dataflow-service-producer-prod.%s", local.service_project_number, local.iam_gsa_domain)
       role            = "roles/compute.networkUser"
     },
     "datafusion.googleapis.com" : {
-      service_account = format("service-%s@gcp-sa-datafusion.iam.gserviceaccount.com", local.service_project_number)
+      service_account = format("service-%s@gcp-sa-datafusion.%s", local.service_project_number, local.iam_gsa_domain)
       role            = "roles/compute.networkViewer"
     },
     "composer.googleapis.com" : {
-      service_account = format("service-%s@cloudcomposer-accounts.iam.gserviceaccount.com", local.service_project_number)
+      service_account = format("service-%s@cloudcomposer-accounts.%s", local.service_project_number, local.iam_gsa_domain)
       role            = "roles/compute.networkUser"
     }
     "vpcaccess.googleapis.com" : {
-      service_account = format("service-%s@gcp-sa-vpcaccess.iam.gserviceaccount.com", local.service_project_number)
+      service_account = format("service-%s@gcp-sa-vpcaccess.%s", local.service_project_number, local.iam_gsa_domain)
       role            = "roles/compute.networkUser"
     }
     "datastream.googleapis.com" : {
-      service_account = format("service-%s@gcp-sa-datastream.iam.gserviceaccount.com", local.service_project_number)
+      service_account = format("service-%s@gcp-sa-datastream.%s", local.service_project_number, local.iam_gsa_domain)
       role            = "roles/compute.networkUser"
     }
     "notebooks.googleapis.com" : {
-      service_account = format("service-%s@gcp-sa-notebooks.iam.gserviceaccount.com", local.service_project_number)
+      service_account = format("service-%s@gcp-sa-notebooks.%s", local.service_project_number, local.iam_gsa_domain)
       role            = "roles/compute.networkUser"
     }
     "networkconnectivity.googleapis.com" : {
-      service_account = format("service-%s@gcp-sa-networkconnectivity.iam.gserviceaccount.com", local.service_project_number)
+      service_account = format("service-%s@gcp-sa-networkconnectivity.%s", local.service_project_number, local.iam_gsa_domain)
       role            = "roles/compute.networkUser"
     }
     "run.googleapis.com" : {
-      service_account = format("service-%s@serverless-robot-prod.iam.gserviceaccount.com", local.service_project_number)
+      service_account = format("service-%s@serverless-robot-prod.%s", local.service_project_number, local.iam_gsa_domain)
       role            = "roles/compute.networkUser"
     }
     "aiplatform.googleapis.com" : {
-      service_account = format("service-%s@gcp-sa-aiplatform.iam.gserviceaccount.com", local.service_project_number)
+      service_account = format("service-%s@gcp-sa-aiplatform.%s", local.service_project_number, local.iam_gsa_domain)
       role            = "roles/compute.networkUser"
     }
     "cloudbuild.googleapis.com" : {
-      service_account = format("%s@cloudbuild.gserviceaccount.com", local.service_project_number)
+      service_account = format("%s@cloudbuild.%s", local.service_project_number, local.gsa_domain)
       role            = "roles/compute.networkUser"
     }
   }
@@ -143,7 +147,7 @@ resource "google_compute_subnetwork_iam_member" "cloudservices_shared_vpc_subnet
     index(split("/", split(",", local.subnetwork_api[count.index])[1]), "regions") + 1,
   )
   project = var.host_project_id
-  member  = format("serviceAccount:%s@cloudservices.gserviceaccount.com", local.service_project_number)
+  member  = format("serviceAccount:%s@cloudservices.%s", local.service_project_number, local.gsa_domain)
 }
 
 /******************************************
@@ -228,7 +232,7 @@ resource "google_project_iam_member" "managed_kafka_service_agent" {
   count   = local.managedkafka_shared_vpc_enabled && var.enable_shared_vpc_service_project && var.grant_network_role ? 1 : 0
   project = var.host_project_id
   role    = "roles/managedkafka.serviceAgent"
-  member  = format("serviceAccount:service-%s@gcp-sa-managedkafka.iam.gserviceaccount.com", local.service_project_number)
+  member  = format("serviceAccount:service-%s@gcp-sa-managedkafka.%s", local.service_project_number, local.iam_gsa_domain)
 }
 
 /******************************************

--- a/modules/shared_vpc_access/main.tf
+++ b/modules/shared_vpc_access/main.tf
@@ -20,7 +20,8 @@ data "google_project" "service_project" {
 }
 
 locals {
-  extracted_prefix = length(regexall(":", var.service_project_id)) > 0 ? split(":", var.service_project_id)[0] : ""
+  raw_prefix       = length(regexall(":", var.service_project_id)) > 0 ? split(":", var.service_project_id)[0] : ""
+  extracted_prefix = length(regexall("\\.", local.raw_prefix)) > 0 ? "" : local.raw_prefix
   gsa_domain       = local.extracted_prefix != "" ? "${local.extracted_prefix}-system.iam.gserviceaccount.com" : "gserviceaccount.com"
   iam_gsa_domain   = local.extracted_prefix != "" ? "${local.extracted_prefix}-system.iam.gserviceaccount.com" : "iam.gserviceaccount.com"
 

--- a/modules/shared_vpc_access/metadata.yaml
+++ b/modules/shared_vpc_access/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -129,6 +129,6 @@ spec:
       - serviceusage.googleapis.com
     providerVersions:
       - source: hashicorp/google
-        version: ">= 3.43, < 7"
+        version: ">= 3.43, < 8"
       - source: hashicorp/google-beta
-        version: ">= 3.43, < 7"
+        version: ">= 3.43, < 8"

--- a/modules/svpc_service_project/README.md
+++ b/modules/svpc_service_project/README.md
@@ -59,12 +59,14 @@ module "service-project" {
 | lien | Add a lien on the project to prevent accidental deletion | `bool` | `false` | no |
 | name | The name for the project | `string` | n/a | yes |
 | org\_id | The organization ID. | `string` | n/a | yes |
+| principal\_set | A principalSet URI to control the project. If provided, this is used instead of group\_name. | `string` | `""` | no |
 | project\_id | The ID to give the project. If not provided, the `name` will be used. | `string` | `""` | no |
 | project\_sa\_name | Default service account name for the project. | `string` | `"project-service-account"` | no |
 | random\_project\_id | Adds a suffix of 4 random characters to the `project_id` | `bool` | `false` | no |
 | sa\_role | A role to give the default Service Account for the project (defaults to none) | `string` | `""` | no |
 | shared\_vpc | The ID of the host project which hosts the shared VPC | `string` | `""` | no |
 | shared\_vpc\_subnets | List of subnets fully qualified subnet IDs (ie. projects/$project\_id/regions/$region/subnetworks/$subnet\_id) | `list(string)` | `[]` | no |
+| universe\_prefix | The universe short name prefix to prepend to the project ID (e.g., 'eu0'). A colon (:) is automatically appended to the project ID, and a hyphen (-) is used for the state bucket name. | `string` | `""` | no |
 | usage\_bucket\_name | Name of a GCS bucket to store GCE usage reports in (optional) | `string` | `""` | no |
 | usage\_bucket\_prefix | Prefix in the GCS bucket to store GCE usage reports in (optional) | `string` | `""` | no |
 

--- a/modules/svpc_service_project/main.tf
+++ b/modules/svpc_service_project/main.tf
@@ -28,11 +28,12 @@ module "gsuite_group" {
 module "project-factory" {
   source = "../core_project_factory"
 
-  group_email                       = module.gsuite_group.email
+  group_email                       = var.principal_set != "" ? var.principal_set : module.gsuite_group.email
   group_role                        = var.group_role
   lien                              = var.lien
-  manage_group                      = var.group_name != "" ? true : false
+  manage_group                      = var.group_name != "" || var.principal_set != ""
   random_project_id                 = var.random_project_id
+  universe_prefix                   = var.universe_prefix
   org_id                            = var.org_id
   name                              = var.name
   project_id                        = var.project_id

--- a/modules/svpc_service_project/metadata.yaml
+++ b/modules/svpc_service_project/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -78,6 +78,10 @@ spec:
         description: The ID to give the project. If not provided, the `name` will be used.
         varType: string
         defaultValue: ""
+      - name: universe_prefix
+        description: The universe short name prefix to prepend to the project ID (e.g., 'eu0'). A colon (:) is automatically appended to the project ID, and a hyphen (-) is used for the state bucket name.
+        varType: string
+        defaultValue: ""
       - name: shared_vpc
         description: The ID of the host project which hosts the shared VPC
         varType: string
@@ -92,6 +96,10 @@ spec:
         defaultValue: ""
       - name: group_name
         description: A group to control the project by being assigned group_role (defaults to project editor)
+        varType: string
+        defaultValue: ""
+      - name: principal_set
+        description: A principalSet URI to control the project. If provided, this is used instead of group_name.
         varType: string
         defaultValue: ""
       - name: group_role
@@ -260,6 +268,6 @@ spec:
       - serviceusage.googleapis.com
     providerVersions:
       - source: hashicorp/google
-        version: ">= 4.5, < 7"
+        version: ">= 4.5, < 8"
       - source: hashicorp/google-beta
-        version: ">= 4.5, < 7"
+        version: ">= 4.5, < 8"

--- a/modules/svpc_service_project/variables.tf
+++ b/modules/svpc_service_project/variables.tf
@@ -42,6 +42,12 @@ variable "project_id" {
   default     = ""
 }
 
+variable "universe_prefix" {
+  description = "The universe short name prefix to prepend to the project ID (e.g., 'eu0'). A colon (:) is automatically appended to the project ID, and a hyphen (-) is used for the state bucket name."
+  type        = string
+  default     = ""
+}
+
 variable "shared_vpc" {
   description = "The ID of the host project which hosts the shared VPC"
   type        = string
@@ -63,6 +69,17 @@ variable "group_name" {
   description = "A group to control the project by being assigned group_role (defaults to project editor)"
   type        = string
   default     = ""
+}
+
+variable "principal_set" {
+  description = "A principalSet URI to control the project. If provided, this is used instead of group_name."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.principal_set == "" || startswith(var.principal_set, "principalSet://")
+    error_message = "The principal_set variable must be empty or start with 'principalSet://'."
+  }
 }
 
 variable "group_role" {

--- a/modules/svpc_service_project/variables.tf
+++ b/modules/svpc_service_project/variables.tf
@@ -46,6 +46,11 @@ variable "universe_prefix" {
   description = "The universe short name prefix to prepend to the project ID (e.g., 'eu0'). A colon (:) is automatically appended to the project ID, and a hyphen (-) is used for the state bucket name."
   type        = string
   default     = ""
+
+  validation {
+    condition     = var.universe_prefix == "" || can(regex("^[a-z0-9]+$", var.universe_prefix))
+    error_message = "The universe_prefix variable must be empty or contain only lowercase alphanumeric characters."
+  }
 }
 
 variable "shared_vpc" {

--- a/variables.tf
+++ b/variables.tf
@@ -26,6 +26,12 @@ variable "random_project_id_length" {
   default     = null
 }
 
+variable "universe_prefix" {
+  description = "The universe short name prefix to prepend to the project ID (e.g., 'eu0'). A colon (:) is automatically appended to the project ID, and a hyphen (-) is used for the state bucket name."
+  type        = string
+  default     = ""
+}
+
 variable "org_id" {
   description = "The organization ID."
   type        = string
@@ -76,6 +82,17 @@ variable "group_name" {
   description = "A group to control the project by being assigned group_role (defaults to project editor)"
   type        = string
   default     = ""
+}
+
+variable "principal_set" {
+  description = "A principalSet URI to control the project. If provided, this is used instead of group_name."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.principal_set == "" || startswith(var.principal_set, "principalSet://")
+    error_message = "The principal_set variable must be empty or start with 'principalSet://'."
+  }
 }
 
 variable "group_role" {

--- a/variables.tf
+++ b/variables.tf
@@ -30,6 +30,11 @@ variable "universe_prefix" {
   description = "The universe short name prefix to prepend to the project ID (e.g., 'eu0'). A colon (:) is automatically appended to the project ID, and a hyphen (-) is used for the state bucket name."
   type        = string
   default     = ""
+
+  validation {
+    condition     = var.universe_prefix == "" || can(regex("^[a-z0-9]+$", var.universe_prefix))
+    error_message = "The universe_prefix variable must be empty or contain only lowercase alphanumeric characters."
+  }
 }
 
 variable "org_id" {


### PR DESCRIPTION
This PR adds support for Google Cloud Universes (Project ID prefixes, GCS naming, PrincipalSets and dynamic SA domains)

Description
Currently, the Project Factory module assumes it is running in the standard Google Cloud public universe. However, when creating GCP projects in other Google Cloud Universes (such as eu0), several hardcoded assumptions in the project factory cause deployment failures.



- Project IDs: The project ID requires a cloud universe short name prefix (e.g., instead of example-project-id, it must be eu0:example-project-id).
- Bucket Names: Google Cloud Storage bucket names do not allow colons (:). If the project ID is used to dynamically generate the state bucket name, the colon must be safely replaced with a hyphen (e.g., eu0-example-project-id-state).
- Group Permissions: Roles granted to `group:` need to allow `principalSet:` identities
- Service Account Domains: Default GCP service account domains change. Standard domains like @cloudservices.gserviceaccount.com and @container-engine-robot.iam.gserviceaccount.com collapse into a single format like @cloudservices.eu0-system.iam.gserviceaccount.com.

The PR also includes a fix for the build issue related to the Access Context Manager ID